### PR TITLE
Automated Changelog Entry for 0.2.0a0 on main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,4 +2,23 @@
 
 <!-- <START NEW CHANGELOG ENTRY> -->
 
+## 0.2.0a0
+
+([Full Changelog](https://github.com/QuantStack/jupyterlab-niryo-one/compare/99737a8b11ccf7be67c38c6cf5710df46b5abb95...fe24c8990bc7f096a90c64e4cd9fabdde176a194))
+
+### Enhancements made
+
+- Extend jupyterlab-blockly [#3](https://github.com/QuantStack/jupyterlab-niryo-one/pull/3) ([@hbcarlos](https://github.com/hbcarlos))
+- added top level initialization  [#1](https://github.com/QuantStack/jupyterlab-niryo-one/pull/1) ([@DenisaCG](https://github.com/DenisaCG))
+
+### Maintenance and upkeep improvements
+
+- Rename repository [#2](https://github.com/QuantStack/jupyterlab-niryo-one/pull/2) ([@hbcarlos](https://github.com/hbcarlos))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/QuantStack/jupyterlab-niryo-one/graphs/contributors?from=2022-07-01&to=2022-07-25&type=c))
+
+[@DenisaCG](https://github.com/search?q=repo%3AQuantStack%2Fjupyterlab-niryo-one+involves%3ADenisaCG+updated%3A2022-07-01..2022-07-25&type=Issues) | [@hbcarlos](https://github.com/search?q=repo%3AQuantStack%2Fjupyterlab-niryo-one+involves%3Ahbcarlos+updated%3A2022-07-01..2022-07-25&type=Issues)
+
 <!-- <END NEW CHANGELOG ENTRY> -->


### PR DESCRIPTION
Automated Changelog Entry for 0.2.0a0 on main
```
Python version: 0.2.0a0
npm version: jupyterlab-niryo-one: 0.2.0-alpha.0
```

After merging this PR run the "Full Release" Workflow on your fork of `jupyter_releaser` with the following inputs
| Input  | Value |
| ------------- | ------------- |
| Target | QuantStack/jupyterlab-niryo-one  |
| Branch  | main  |
| Version Spec | 0.2.0-alpha.0 |
