### PR TITLE
Update existing blocks to newest API and add new blocks

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
   "dependencies": {
     "@jupyterlab/application": "^3.4",
     "blockly": "^7.20211209.2",
-    "jupyterlab-blockly": "^0.1.0-alpha.4",
+    "jupyterlab-blockly": "^0.1.0",
     "patch-package": "^6.4.7",
     "postinstall-postinstall": "^2.1.0"
   },

--- a/src/niryo_one_python_generators.js
+++ b/src/niryo_one_python_generators.js
@@ -59,7 +59,8 @@ const g_shape_values = {
  *  Blocks definition
  */
 
-// Movement
+// Connection
+
 Blockly.Blocks['niryo_one_connect'] = {
   init: function () {
     this.appendDummyInput().appendField('IP Address');
@@ -80,6 +81,103 @@ Blockly.Blocks['niryo_one_connect'] = {
     this.setHelpUrl('');
   }
 };
+
+Blockly.Blocks['niryo_one_need_calibration'] = {
+  init: function () {
+    this.appendDummyInput().appendField('Need calibration');
+    this.setOutput(true, 'Boolean');
+    this.setColour(function_color);
+    this.setTooltip(
+      'Return a bool indicating whereas the robot motors need to be calibrate'
+    );
+    this.setHelpUrl('');
+  }
+};
+
+Blockly.Blocks['niryo_one_calibrate_auto'] = {
+  init: function () {
+    this.appendDummyInput().appendField('Calibrate motors (auto)');
+    this.setPreviousStatement(true, null);
+    this.setNextStatement(true, null);
+    this.setColour(function_color);
+    this.setTooltip(
+      'Will auto calibrate motors. If already calibrated, will do nothing.'
+    );
+    this.setHelpUrl('');
+  }
+};
+
+Blockly.Blocks['niryo_one_calibrate'] = {
+  init: function () {
+    this.appendDummyInput()
+      .appendField(
+        new Blockly.FieldDropdown([
+          ['Auto', 'Auto'],
+          ['Manual', 'Manual']
+        ]),
+        'CALIBRATE_MODE'
+      )
+      .appendField('calibrate mode');
+    this.setPreviousStatement(true, null);
+    this.setNextStatement(true, null);
+    this.setColour(function_color);
+    this.setTooltip(
+      'Will auto or manually calibrate motors (robot needs to be in home position for manual calibration). If already calibrated, will do nothing.'
+    );
+    this.setHelpUrl('');
+  }
+};
+
+Blockly.Blocks['niryo_one_get_learning_mode'] = {
+  init: function () {
+    this.appendDummyInput().appendField('Get Learning Mode');
+    this.setOutput(true, 'Boolean');
+    this.setColour(function_color);
+    this.setTooltip('Set learning mode if param is True, else turn it off.');
+    this.setHelpUrl('');
+  }
+};
+
+Blockly.Blocks['niryo_one_activate_learning_mode'] = {
+  init: function () {
+    this.appendDummyInput()
+      .appendField(
+        new Blockly.FieldDropdown([
+          ['Activate', '1'],
+          ['Deactivate', '0']
+        ]),
+        'LEARNING_MODE_VALUE'
+      )
+      .appendField('learning mode');
+    this.setPreviousStatement(true, null);
+    this.setNextStatement(true, null);
+    this.setColour(function_color);
+    this.setTooltip('Set learning mode if param is True, else turn it off.');
+    this.setHelpUrl('');
+  }
+};
+
+Blockly.Blocks['niryo_one_set_jog_control'] = {
+  init: function () {
+    this.appendDummyInput()
+      .appendField(
+        new Blockly.FieldDropdown([
+          ['Activate', '1'],
+          ['Deactivate', '0']
+        ]),
+        'JOG_CONTROL_MODE_VALUE'
+      )
+      .appendField('Jog control mode');
+    this.setPreviousStatement(true, null);
+    this.setNextStatement(true, null);
+    this.setColour(function_color);
+    this.setTooltip('Set jog control mode if param is True, else turn it off:');
+    this.setHelpUrl('');
+  }
+};
+
+// Movement
+
 Blockly.Blocks['niryo_one_move_joints'] = {
   init: function () {
     this.appendDummyInput().appendField('Move Joints');
@@ -121,6 +219,16 @@ Blockly.Blocks['niryo_one_move_joints'] = {
     this.setTooltip(
       'Give all 6 joints to move the robot. Joints are expressed in radians.'
     );
+    this.setHelpUrl('');
+  }
+};
+
+Blockly.Blocks['niryo_one_get_joints'] = {
+  init: function () {
+    this.appendDummyInput().appendField('Get joints values');
+    this.setOutput(true, null);
+    this.setColour(movement_color);
+    this.setTooltip('Get joints value in radians. You can also use a getter');
     this.setHelpUrl('');
   }
 };
@@ -170,6 +278,73 @@ Blockly.Blocks['niryo_one_move_pose'] = {
   }
 };
 
+Blockly.Blocks['niryo_one_move_linear_pose'] = {
+  init: function () {
+    this.appendDummyInput().appendField('Move Linear Pose');
+    this.appendDummyInput()
+      .appendField('x')
+      .appendField(
+        new Blockly.FieldNumber(0, -Infinity, Infinity, 0.001),
+        'POSE_X'
+      )
+      .appendField('y')
+      .appendField(
+        new Blockly.FieldNumber(0, -Infinity, Infinity, 0.001),
+        'POSE_Y'
+      )
+      .appendField('z')
+      .appendField(
+        new Blockly.FieldNumber(0, -Infinity, Infinity, 0.001),
+        'POSE_Z'
+      )
+      .appendField('roll')
+      .appendField(
+        new Blockly.FieldNumber(0, -Infinity, Infinity, 0.001),
+        'POSE_ROLL'
+      )
+      .appendField('pitch')
+      .appendField(
+        new Blockly.FieldNumber(0, -Infinity, Infinity, 0.001),
+        'POSE_PITCH'
+      )
+      .appendField('yaw')
+      .appendField(
+        new Blockly.FieldNumber(0, -Infinity, Infinity, 0.001),
+        'POSE_YAW'
+      );
+    this.setInputsInline(true);
+    this.setPreviousStatement(true, null);
+    this.setNextStatement(true, null);
+    this.setColour(movement_color);
+    this.setTooltip(
+      'Move robot end effector pose to a (x, y, z, roll, pitch, yaw) pose with a linear trajectory.'
+    );
+    this.setHelpUrl('');
+  }
+};
+
+Blockly.Blocks['niryo_one_get_pose'] = {
+  init: function () {
+    this.appendDummyInput().appendField('Get pose value');
+    this.setOutput(true, null);
+    this.setColour(movement_color);
+    this.setTooltip(
+      'Get end effector link pose as [x, y, z, roll, pitch, yaw]. x, y & z are expressed in meters / roll, pitch & yaw are expressed in radians You can also use a getter'
+    );
+    this.setHelpUrl('');
+  }
+};
+
+Blockly.Blocks['niryo_one_get_pose_quat'] = {
+  init: function () {
+    this.appendDummyInput().appendField('Get pose value (quaternion)');
+    this.setOutput(true, null);
+    this.setColour(movement_color);
+    this.setTooltip('Get end effector link pose in Quaternion coordinates.');
+    this.setHelpUrl('');
+  }
+};
+
 Blockly.Blocks['niryo_one_shift_pose'] = {
   init: function () {
     this.appendDummyInput().appendField('Shift');
@@ -199,6 +374,37 @@ Blockly.Blocks['niryo_one_shift_pose'] = {
   }
 };
 
+Blockly.Blocks['niryo_one_shift_linear_pose'] = {
+  init: function () {
+    this.appendDummyInput().appendField('Shift linear');
+    this.appendDummyInput()
+      .appendField(
+        new Blockly.FieldDropdown([
+          ['pos. x', '0'],
+          ['pos. y', '1'],
+          ['pos. z', '2'],
+          ['rot. x', '3'],
+          ['rot. y', '4'],
+          ['rot. z', '5']
+        ]),
+        'SHIFT_POSE_AXIS'
+      )
+      .appendField('by')
+      .appendField(
+        new Blockly.FieldNumber(0, -Infinity, Infinity, 0.001),
+        'SHIFT_POSE_VALUE'
+      );
+    this.setInputsInline(true);
+    this.setPreviousStatement(true, null);
+    this.setNextStatement(true, null);
+    this.setColour(movement_color);
+    this.setTooltip(
+      'Shift robot end effector pose along one axis, with a linear trajectory.'
+    );
+    this.setHelpUrl('');
+  }
+};
+
 Blockly.Blocks['niryo_one_set_arm_max_speed'] = {
   init: function () {
     this.appendValueInput('SET_ARM_MAX_SPEED')
@@ -212,59 +418,6 @@ Blockly.Blocks['niryo_one_set_arm_max_speed'] = {
     this.setTooltip(
       'Limit arm max velocity to a percentage of its maximum velocity. Should be between 1 & 100'
     );
-    this.setHelpUrl('');
-  }
-};
-
-Blockly.Blocks['niryo_one_calibrate_auto'] = {
-  init: function () {
-    this.appendDummyInput().appendField('Calibrate motors (auto)');
-    this.setPreviousStatement(true, null);
-    this.setNextStatement(true, null);
-    this.setColour(movement_color);
-    this.setTooltip(
-      'Will auto calibrate motors. If already calibrated, will do nothing.'
-    );
-    this.setHelpUrl('');
-  }
-};
-
-Blockly.Blocks['niryo_one_calibrate'] = {
-  init: function () {
-    this.appendDummyInput()
-      .appendField(
-        new Blockly.FieldDropdown([
-          ['Auto', 'Auto'],
-          ['Manual', 'Manual']
-        ]),
-        'CALIBRATE_MODE'
-      )
-      .appendField('calibrate mode');
-    this.setPreviousStatement(true, null);
-    this.setNextStatement(true, null);
-    this.setColour(movement_color);
-    this.setTooltip(
-      'Will auto or manually calibrate motors (robot needs to be in home position for manual calibration). If already calibrated, will do nothing.'
-    );
-    this.setHelpUrl('');
-  }
-};
-
-Blockly.Blocks['niryo_one_activate_learning_mode'] = {
-  init: function () {
-    this.appendDummyInput()
-      .appendField(
-        new Blockly.FieldDropdown([
-          ['Activate', '1'],
-          ['Deactivate', '0']
-        ]),
-        'LEARNING_MODE_VALUE'
-      )
-      .appendField('learning mode');
-    this.setPreviousStatement(true, null);
-    this.setNextStatement(true, null);
-    this.setColour(movement_color);
-    this.setTooltip('Set learning mode if param is True, else turn it off.');
     this.setHelpUrl('');
   }
 };
@@ -329,19 +482,6 @@ Blockly.Blocks['niryo_one_pose'] = {
   }
 };
 
-Blockly.Blocks['niryo_one_move_pose_from_pose'] = {
-  init: function () {
-    this.appendValueInput('POSE')
-      .setCheck('niryo_one_pose')
-      .appendField('Move pose');
-    this.setPreviousStatement(true, null);
-    this.setNextStatement(true, null);
-    this.setColour(movement_color);
-    this.setTooltip('Move pose with an object pose given');
-    this.setHelpUrl('');
-  }
-};
-
 Blockly.Blocks['niryo_one_pick_from_pose'] = {
   init: function () {
     this.appendValueInput('POSE')
@@ -352,6 +492,27 @@ Blockly.Blocks['niryo_one_pick_from_pose'] = {
     this.setColour(movement_color);
     this.setTooltip(
       'Execute a picking from a pose. A picking is described as: going over the object, going down until height = z, grasping with tool, going back over the object'
+    );
+    this.setHelpUrl('');
+  }
+};
+
+Blockly.Blocks['niryo_one_pick_and_place'] = {
+  init: function () {
+    this.appendValueInput('POSE_1')
+      .setCheck('niryo_one_pose')
+      .appendField('Pick from pose');
+    this.appendValueInput('POSE_2')
+      .setCheck('niryo_one_pose')
+      .appendField('and place from pose');
+    this.appendValueInput('DIST_SMOOTHING')
+      .setCheck('Number')
+      .appendField('with distance smoothing');
+    this.setPreviousStatement(true, null);
+    this.setNextStatement(true, null);
+    this.setColour(movement_color);
+    this.setTooltip(
+      'Execute a pick and a place. Distance smoothing refers to distance from waypoints before smoothing trajectory.'
     );
     this.setHelpUrl('');
   }
@@ -368,6 +529,287 @@ Blockly.Blocks['niryo_one_place_from_pose'] = {
     this.setTooltip(
       'Execute a placing from a position. A placing is described as: going over the place, going down until height = z, releasing the object with tool, going back over the place'
     );
+    this.setHelpUrl('');
+  }
+};
+
+Blockly.Blocks['niryo_one_jog_joints'] = {
+  init: function () {
+    this.appendDummyInput().appendField('Jog Joints');
+    this.appendDummyInput()
+      .appendField('j1')
+      .appendField(
+        new Blockly.FieldNumber(0, -Infinity, Infinity, 0.001),
+        'JOINTS_1'
+      )
+      .appendField('j2')
+      .appendField(
+        new Blockly.FieldNumber(0, -Infinity, Infinity, 0.001),
+        'JOINTS_2'
+      )
+      .appendField('j3')
+      .appendField(
+        new Blockly.FieldNumber(0, -Infinity, Infinity, 0.001),
+        'JOINTS_3'
+      )
+      .appendField('j4')
+      .appendField(
+        new Blockly.FieldNumber(0, -Infinity, Infinity, 0.001),
+        'JOINTS_4'
+      )
+      .appendField('j5')
+      .appendField(
+        new Blockly.FieldNumber(0, -Infinity, Infinity, 0.001),
+        'JOINTS_5'
+      )
+      .appendField('j6')
+      .appendField(
+        new Blockly.FieldNumber(0, -Infinity, Infinity, 0.001),
+        'JOINTS_6'
+      );
+    this.setInputsInline(true);
+    this.setPreviousStatement(true, null);
+    this.setNextStatement(true, null);
+    this.setColour(movement_color);
+    this.setTooltip(
+      'Jog robot joints’. Jog corresponds to a shift without motion planning. Values are expressed in radians.'
+    );
+    this.setHelpUrl('');
+  }
+};
+
+Blockly.Blocks['niryo_one_jog_pose'] = {
+  init: function () {
+    this.appendDummyInput().appendField('Jog Pose');
+    this.appendDummyInput()
+      .appendField('x')
+      .appendField(
+        new Blockly.FieldNumber(0, -Infinity, Infinity, 0.001),
+        'POSE_X'
+      )
+      .appendField('y')
+      .appendField(
+        new Blockly.FieldNumber(0, -Infinity, Infinity, 0.001),
+        'POSE_Y'
+      )
+      .appendField('z')
+      .appendField(
+        new Blockly.FieldNumber(0, -Infinity, Infinity, 0.001),
+        'POSE_Z'
+      )
+      .appendField('roll')
+      .appendField(
+        new Blockly.FieldNumber(0, -Infinity, Infinity, 0.001),
+        'POSE_ROLL'
+      )
+      .appendField('pitch')
+      .appendField(
+        new Blockly.FieldNumber(0, -Infinity, Infinity, 0.001),
+        'POSE_PITCH'
+      )
+      .appendField('yaw')
+      .appendField(
+        new Blockly.FieldNumber(0, -Infinity, Infinity, 0.001),
+        'POSE_YAW'
+      );
+    this.setInputsInline(true);
+    this.setPreviousStatement(true, null);
+    this.setNextStatement(true, null);
+    this.setColour(movement_color);
+    this.setTooltip(
+      'Jog robot end effector pose Jog corresponds to a shift without motion planning Arguments are [dx, dy, dz, d_roll, d_pitch, d_yaw] dx, dy & dz are expressed in meters / d_roll, d_pitch & d_yaw are expressed in radians'
+    );
+    this.setHelpUrl('');
+  }
+};
+
+Blockly.Blocks['niryo_one_move_to_home_pose'] = {
+  init: function () {
+    this.appendDummyInput().appendField('Move to home pose');
+    this.setPreviousStatement(true, null);
+    this.setNextStatement(true, null);
+    this.setColour(movement_color);
+    this.setTooltip('Move to a position where the forearm lays on shoulder.');
+    this.setHelpUrl('');
+  }
+};
+
+Blockly.Blocks['niryo_one_sleep'] = {
+  init: function () {
+    this.appendDummyInput().appendField('Go to sleep');
+    this.setPreviousStatement(true, null);
+    this.setNextStatement(true, null);
+    this.setColour(movement_color);
+    this.setTooltip('Go to home pose and activate learning mode.');
+    this.setHelpUrl('');
+  }
+};
+
+Blockly.Blocks['niryo_one_forward_kinematics'] = {
+  init: function () {
+    this.appendDummyInput().appendField('Forward Kinematics of Joints');
+    this.appendDummyInput()
+      .appendField('j1')
+      .appendField(
+        new Blockly.FieldNumber(0, -Infinity, Infinity, 0.001),
+        'JOINTS_1'
+      )
+      .appendField('j2')
+      .appendField(
+        new Blockly.FieldNumber(0, -Infinity, Infinity, 0.001),
+        'JOINTS_2'
+      )
+      .appendField('j3')
+      .appendField(
+        new Blockly.FieldNumber(0, -Infinity, Infinity, 0.001),
+        'JOINTS_3'
+      )
+      .appendField('j4')
+      .appendField(
+        new Blockly.FieldNumber(0, -Infinity, Infinity, 0.001),
+        'JOINTS_4'
+      )
+      .appendField('j5')
+      .appendField(
+        new Blockly.FieldNumber(0, -Infinity, Infinity, 0.001),
+        'JOINTS_5'
+      )
+      .appendField('j6')
+      .appendField(
+        new Blockly.FieldNumber(0, -Infinity, Infinity, 0.001),
+        'JOINTS_6'
+      );
+    this.setInputsInline(true);
+    this.setOutput(true, null);
+    this.setColour(movement_color);
+    this.setTooltip(
+      'Compute forward kinematics of a given joints configuration and give the associated spatial pose'
+    );
+    this.setHelpUrl('');
+  }
+};
+
+Blockly.Blocks['niryo_one_inverse_kinematics'] = {
+  init: function () {
+    this.appendDummyInput().appendField('Inverse Kinematics of Pose');
+    this.appendDummyInput()
+      .appendField('x')
+      .appendField(
+        new Blockly.FieldNumber(0, -Infinity, Infinity, 0.001),
+        'POSE_X'
+      )
+      .appendField('y')
+      .appendField(
+        new Blockly.FieldNumber(0, -Infinity, Infinity, 0.001),
+        'POSE_Y'
+      )
+      .appendField('z')
+      .appendField(
+        new Blockly.FieldNumber(0, -Infinity, Infinity, 0.001),
+        'POSE_Z'
+      )
+      .appendField('roll')
+      .appendField(
+        new Blockly.FieldNumber(0, -Infinity, Infinity, 0.001),
+        'POSE_ROLL'
+      )
+      .appendField('pitch')
+      .appendField(
+        new Blockly.FieldNumber(0, -Infinity, Infinity, 0.001),
+        'POSE_PITCH'
+      )
+      .appendField('yaw')
+      .appendField(
+        new Blockly.FieldNumber(0, -Infinity, Infinity, 0.001),
+        'POSE_YAW'
+      );
+    this.setInputsInline(true);
+    this.setOutput(true, null);
+    this.setColour(movement_color);
+    this.setTooltip('Compute inverse kinematics.');
+    this.setHelpUrl('');
+  }
+};
+
+// Saved poses
+
+Blockly.Blocks['niryo_one_get_saved_pose'] = {
+  init: function () {
+    this.appendValueInput('POSE_NAME')
+      .setCheck('String')
+      .appendField('Get pose named');
+    this.setOutput(true, null);
+    this.setColour(movement_color);
+    this.setTooltip('Get pose saved in from Niryo’s memory');
+    this.setHelpUrl('');
+  }
+};
+
+Blockly.Blocks['niryo_one_save_pose'] = {
+  init: function () {
+    this.appendDummyInput()
+      .appendField('Save pose')
+      .appendField('x')
+      .appendField(
+        new Blockly.FieldNumber(0, -Infinity, Infinity, 0.001),
+        'POSE_X'
+      )
+      .appendField('y')
+      .appendField(
+        new Blockly.FieldNumber(0, -Infinity, Infinity, 0.001),
+        'POSE_Y'
+      )
+      .appendField('z')
+      .appendField(
+        new Blockly.FieldNumber(0, -Infinity, Infinity, 0.001),
+        'POSE_Z'
+      )
+      .appendField('roll')
+      .appendField(
+        new Blockly.FieldNumber(0, -Infinity, Infinity, 0.001),
+        'POSE_ROLL'
+      )
+      .appendField('pitch')
+      .appendField(
+        new Blockly.FieldNumber(0, -Infinity, Infinity, 0.001),
+        'POSE_PITCH'
+      )
+      .appendField('yaw')
+      .appendField(
+        new Blockly.FieldNumber(0, -Infinity, Infinity, 0.001),
+        'POSE_YAW'
+      );
+    this.appendValueInput('POSE_NAME')
+      .setCheck('String')
+      .appendField('under the name');
+    this.setInputsInline(true);
+    this.setPreviousStatement(true, null);
+    this.setNextStatement(true, null);
+    this.setColour(movement_color);
+    this.setTooltip("Save pose in Niryo's memory.");
+    this.setHelpUrl('');
+  }
+};
+
+Blockly.Blocks['niryo_one_delete_pose'] = {
+  init: function () {
+    this.appendValueInput('POSE_NAME')
+      .setCheck('String')
+      .appendField('Delete pose named');
+    this.setPreviousStatement(true, null);
+    this.setNextStatement(true, null);
+    this.setColour(movement_color);
+    this.setTooltip('Delete pose from Niryo’s memory');
+    this.setHelpUrl('');
+  }
+};
+
+Blockly.Blocks['niryo_one_get_saved_pose_list'] = {
+  init: function () {
+    this.appendDummyInput().appendField('Get list of saved poses');
+    this.setOutput(true, null);
+    this.setColour(movement_color);
+    this.setTooltip('');
     this.setHelpUrl('');
   }
 };
@@ -673,9 +1115,9 @@ Blockly.Blocks['niryo_one_deactivate_electromagnet'] = {
 
 // Utility
 
-Blockly.Blocks['niryo_one_sleep'] = {
+Blockly.Blocks['niryo_one_wait'] = {
   init: function () {
-    this.appendValueInput('SLEEP_TIME')
+    this.appendValueInput('WAIT_TIME')
       .setCheck('Number')
       .appendField('Wait for ');
     this.appendDummyInput().appendField('seconds');
@@ -890,6 +1332,41 @@ class niryo_connect():
 
 `;
 
+BlocklyPy['niryo_one_need_calibration'] = function (block) {
+  var code = 'n.need_calibration()\n';
+  return code;
+};
+
+BlocklyPy['niryo_one_calibrate_auto'] = function (block) {
+  var code = 'n.calibrate_auto()\n';
+  return code;
+};
+
+BlocklyPy['niryo_one_calibrate'] = function (block) {
+  var dropdown_calibrate_mode = block.getFieldValue('CALIBRATE_MODE');
+  var code = 'n.calibrate(' + dropdown_calibrate_mode + ')\n';
+  return code;
+};
+
+BlocklyPy['niryo_one_activate_learning_mode'] = function (block) {
+  var dropdown_learning_mode_value = block.getFieldValue('LEARNING_MODE_VALUE');
+  var code = 'n.set_learning_mode(' + dropdown_learning_mode_value + ')\n';
+  return code;
+};
+
+BlocklyPy['niryo_one_get_learning_mode'] = function (block) {
+  var code = 'n.get_learning_mode()\n';
+  return code;
+};
+
+BlocklyPy['niryo_one_set_jog_control'] = function (block) {
+  var dropdown_jog_control_mode_value = block.getFieldValue(
+    'JOG_CONTROL_MODE_VALUE'
+  );
+  var code = 'n.set_jog_control(' + dropdown_jog_control_mode_value + ')\n';
+  return code;
+};
+
 BlocklyPy['niryo_one_move_joints'] = function (block) {
   var number_joints_1 = block.getFieldValue('JOINTS_1');
   var number_joints_2 = block.getFieldValue('JOINTS_2');
@@ -940,6 +1417,31 @@ BlocklyPy['niryo_one_move_pose'] = function (block) {
   return code;
 };
 
+BlocklyPy['niryo_one_move_linear_pose'] = function (block) {
+  var number_pose_x = block.getFieldValue('POSE_X');
+  var number_pose_y = block.getFieldValue('POSE_Y');
+  var number_pose_z = block.getFieldValue('POSE_Z');
+  var number_pose_roll = block.getFieldValue('POSE_ROLL');
+  var number_pose_pitch = block.getFieldValue('POSE_PITCH');
+  var number_pose_yaw = block.getFieldValue('POSE_YAW');
+
+  var code =
+    'n.move_pose(' +
+    number_pose_x +
+    ', ' +
+    number_pose_y +
+    ', ' +
+    number_pose_z +
+    ', ' +
+    number_pose_roll +
+    ', ' +
+    number_pose_pitch +
+    ', ' +
+    number_pose_yaw +
+    ')\n';
+  return code;
+};
+
 BlocklyPy['niryo_one_shift_pose'] = function (block) {
   var dropdown_shift_pose_axis = block.getFieldValue('SHIFT_POSE_AXIS');
   var number_shift_pose_value = block.getFieldValue('SHIFT_POSE_VALUE');
@@ -961,23 +1463,6 @@ BlocklyPy['niryo_one_set_arm_max_speed'] = function (block) {
     .replace('(', '')
     .replace(')', '');
   var code = 'n.set_arm_max_velocity(' + value_set_arm_max_speed + ')\n';
-  return code;
-};
-
-BlocklyPy['niryo_one_calibrate_auto'] = function (block) {
-  var code = 'n.calibrate_auto()\n';
-  return code;
-};
-
-BlocklyPy['niryo_one_calibrate'] = function (block) {
-  var dropdown_calibrate_mode = block.getFieldValue('CALIBRATE_MODE');
-  var code = 'n.calibrate(' + dropdown_calibrate_mode + ')\n';
-  return code;
-};
-
-BlocklyPy['niryo_one_activate_learning_mode'] = function (block) {
-  var dropdown_learning_mode_value = block.getFieldValue('LEARNING_MODE_VALUE');
-  var code = 'n.set_learning_mode(' + dropdown_learning_mode_value + ')\n';
   return code;
 };
 
@@ -1016,6 +1501,11 @@ BlocklyPy['niryo_one_joint'] = function (block) {
     value_j6 +
     ']';
   return [code, BlocklyPy.ORDER_NONE];
+};
+
+BlocklyPy['niryo_one_get_joints'] = function (block) {
+  var code = 'n.get_joints()\n';
+  return code;
 };
 
 BlocklyPy['niryo_one_move_joint_from_joint'] = function (block) {
@@ -1072,6 +1562,16 @@ BlocklyPy['niryo_one_pose'] = function (block) {
   return [code, BlocklyPy.ORDER_NONE];
 };
 
+BlocklyPy['niryo_one_get_pose'] = function (block) {
+  var code = 'n.get_pose()\n';
+  return code;
+};
+
+BlocklyPy['niryo_one_get_pose_quat'] = function (block) {
+  var code = 'n.get_pose_quat()\n';
+  return code;
+};
+
 BlocklyPy['niryo_one_move_pose_from_pose'] = function (block) {
   // Position object
   var value_pose = BlocklyPy.valueToCode(block, 'POSE', BlocklyPy.ORDER_ATOMIC);
@@ -1096,6 +1596,209 @@ BlocklyPy['niryo_one_place_from_pose'] = function (block) {
   value_pose = value_pose.replace('(', '').replace(')', '');
 
   var code = 'n.place_from_pose(*' + value_pose + ')\n';
+  return code;
+};
+
+BlocklyPy['niryo_one_pick_and_place'] = function (block) {
+  var value_pose_1 = BlocklyPy.valueToCode(
+    block,
+    'POSE_1',
+    BlocklyPy.ORDER_ATOMIC
+  );
+  value_pose_1 = value_pose_1.replace('(', '').replace(')', '');
+
+  var value_pose_2 = BlocklyPy.valueToCode(
+    block,
+    'POSE_2',
+    BlocklyPy.ORDER_ATOMIC
+  );
+  value_pose_2 = value_pose_2.replace('(', '').replace(')', '');
+
+  var dist_smoothing_value = Blockly.Python.valueToCode(
+    block,
+    'DIST_SMOOTHING',
+    BlocklyPy.ORDER_ATOMIC
+  );
+  // dist_smoothing_value = dist_smoothing_value.replace('(', '').replace(')', '');
+
+  var code =
+    'n.pick_and_place(*' +
+    value_pose_1 +
+    ', *' +
+    value_pose_2 +
+    ', ' +
+    dist_smoothing_value +
+    ')\n';
+  return [code, BlocklyPy.ORDER_NONE];
+};
+
+BlocklyPy['niryo_one_jog_joints'] = function (block) {
+  var number_joints_1 = block.getFieldValue('JOINTS_1');
+  var number_joints_2 = block.getFieldValue('JOINTS_2');
+  var number_joints_3 = block.getFieldValue('JOINTS_3');
+  var number_joints_4 = block.getFieldValue('JOINTS_4');
+  var number_joints_5 = block.getFieldValue('JOINTS_5');
+  var number_joints_6 = block.getFieldValue('JOINTS_6');
+
+  var code =
+    'n.jog_joints([' +
+    number_joints_1 +
+    ', ' +
+    number_joints_2 +
+    ', ' +
+    number_joints_3 +
+    ', ' +
+    number_joints_4 +
+    ', ' +
+    number_joints_5 +
+    ', ' +
+    number_joints_6 +
+    '])\n';
+  return code;
+};
+
+BlocklyPy['niryo_one_jog_pose'] = function (block) {
+  var number_pose_x = block.getFieldValue('POSE_X');
+  var number_pose_y = block.getFieldValue('POSE_Y');
+  var number_pose_z = block.getFieldValue('POSE_Z');
+  var number_pose_roll = block.getFieldValue('POSE_ROLL');
+  var number_pose_pitch = block.getFieldValue('POSE_PITCH');
+  var number_pose_yaw = block.getFieldValue('POSE_YAW');
+
+  var code =
+    'n.jog_pose(' +
+    number_pose_x +
+    ', ' +
+    number_pose_y +
+    ', ' +
+    number_pose_z +
+    ', ' +
+    number_pose_roll +
+    ', ' +
+    number_pose_pitch +
+    ', ' +
+    number_pose_yaw +
+    ')\n';
+  return code;
+};
+
+BlocklyPy['niryo_one_move_to_home_pose'] = function (block) {
+  var code = 'n.move_to_home_pose()\n';
+  return code;
+};
+
+BlocklyPy['niryo_one_sleep'] = function (block) {
+  var code = 'n.go_to_sleep()\n';
+  return code;
+};
+
+BlocklyPy['niryo_one_forward_kinematics'] = function (block) {
+  var number_joints_1 = block.getFieldValue('JOINTS_1');
+  var number_joints_2 = block.getFieldValue('JOINTS_2');
+  var number_joints_3 = block.getFieldValue('JOINTS_3');
+  var number_joints_4 = block.getFieldValue('JOINTS_4');
+  var number_joints_5 = block.getFieldValue('JOINTS_5');
+  var number_joints_6 = block.getFieldValue('JOINTS_6');
+
+  var code =
+    'n.forward_kinematics([' +
+    number_joints_1 +
+    ', ' +
+    number_joints_2 +
+    ', ' +
+    number_joints_3 +
+    ', ' +
+    number_joints_4 +
+    ', ' +
+    number_joints_5 +
+    ', ' +
+    number_joints_6 +
+    '])\n';
+  return code;
+};
+
+BlocklyPy['niryo_one_inverse_kinematics'] = function (block) {
+  var number_pose_x = block.getFieldValue('POSE_X');
+  var number_pose_y = block.getFieldValue('POSE_Y');
+  var number_pose_z = block.getFieldValue('POSE_Z');
+  var number_pose_roll = block.getFieldValue('POSE_ROLL');
+  var number_pose_pitch = block.getFieldValue('POSE_PITCH');
+  var number_pose_yaw = block.getFieldValue('POSE_YAW');
+
+  var code =
+    'n.inverse_kinematics(' +
+    number_pose_x +
+    ', ' +
+    number_pose_y +
+    ', ' +
+    number_pose_z +
+    ', ' +
+    number_pose_roll +
+    ', ' +
+    number_pose_pitch +
+    ', ' +
+    number_pose_yaw +
+    ')\n';
+  return code;
+};
+
+// Saved poses
+
+BlocklyPy['niryo_one_get_saved_pose'] = function (block) {
+  var value_pose_name = Blockly.Python.valueToCode(
+    block,
+    'POSE_NAME',
+    Blockly.Python.ORDER_ATOMIC
+  );
+  var code = 'n.get_saved_pose(' + value_pose_name + ')\n';
+  return [code, Blockly.Python.ORDER_NONE];
+};
+
+BlocklyPy['niryo_one_save_pose'] = function (block) {
+  var pose_name = Blockly.Python.valueToCode(
+    block,
+    'POSE_NAME',
+    Blockly.Python.ORDER_ATOMIC
+  );
+
+  var number_pose_x = block.getFieldValue('POSE_X');
+  var number_pose_y = block.getFieldValue('POSE_Y');
+  var number_pose_z = block.getFieldValue('POSE_Z');
+  var number_pose_roll = block.getFieldValue('POSE_ROLL');
+  var number_pose_pitch = block.getFieldValue('POSE_PITCH');
+  var number_pose_yaw = block.getFieldValue('POSE_YAW');
+
+  var code =
+    'n.save_pose(' +
+    pose_name +
+    ', ' +
+    number_pose_x +
+    ', ' +
+    number_pose_y +
+    ', ' +
+    number_pose_z +
+    ', ' +
+    number_pose_roll +
+    ', ' +
+    number_pose_pitch +
+    ', ' +
+    number_pose_yaw +
+    ')\n';
+  return [code, Blockly.Python.ORDER_NONE];
+};
+
+BlocklyPy['niryo_one_delete_pose'] = function (block) {
+  var pose_name = Blockly.Python.valueToCode(
+    block,
+    'POSE_NAME',
+    Blockly.Python.ORDER_ATOMIC
+  );
+  var code = 'n.delete_pose(' + pose_name + ')\n';
+  return [code, Blockly.Python.ORDER_NONE];
+};
+
+BlocklyPy['niryo_one_get_saved_pose_list'] = function (block) {
+  var code = 'n.get_saved_pose_list()\n';
   return code;
 };
 
@@ -1252,11 +1955,11 @@ BlocklyPy['niryo_one_deactivate_electromagnet'] = function (block) {
 
 // Utility
 
-BlocklyPy['niryo_one_sleep'] = function (block) {
-  var value_sleep_time =
-    BlocklyPy.valueToCode(block, 'SLEEP_TIME', BlocklyPy.ORDER_ATOMIC) || '0';
-  value_sleep_time = value_sleep_time.replace('(', '').replace(')', '');
-  var code = 'n.wait(' + value_sleep_time + ')\n';
+BlocklyPy['niryo_one_wait'] = function (block) {
+  var value_wait_time =
+    BlocklyPy.valueToCode(block, 'WAIT_TIME', BlocklyPy.ORDER_ATOMIC) || '0';
+  value_wait_time = value_wait_time.replace('(', '').replace(')', '');
+  var code = 'n.wait(' + value_wait_time + ')\n';
   return code;
 };
 
@@ -1760,22 +2463,6 @@ const TOOLBOX = {
         },
         {
           kind: 'BLOCK',
-          type: 'niryo_one_move_joints'
-        },
-        {
-          kind: 'BLOCK',
-          type: 'niryo_one_move_pose'
-        },
-        {
-          kind: 'BLOCK',
-          type: 'niryo_one_shift_pose'
-        },
-        {
-          kind: 'BLOCK',
-          type: 'niryo_one_set_arm_max_speed'
-        },
-        {
-          kind: 'BLOCK',
           type: 'niryo_one_calibrate_auto'
         },
         {
@@ -1784,7 +2471,55 @@ const TOOLBOX = {
         },
         {
           kind: 'BLOCK',
+          type: 'niryo_one_need_calibration'
+        },
+        {
+          kind: 'BLOCK',
           type: 'niryo_one_activate_learning_mode'
+        },
+        {
+          kind: 'BLOCK',
+          type: 'niryo_one_get_learning_mode'
+        },
+        {
+          kind: 'BLOCK',
+          type: 'niryo_one_set_jog_control'
+        },
+        {
+          kind: 'BLOCK',
+          type: 'niryo_one_move_joints'
+        },
+        {
+          kind: 'BLOCK',
+          type: 'niryo_one_get_joints'
+        },
+        {
+          kind: 'BLOCK',
+          type: 'niryo_one_move_pose'
+        },
+        {
+          kind: 'BLOCK',
+          type: 'niryo_one_move_linear_pose'
+        },
+        {
+          kind: 'BLOCK',
+          type: 'niryo_one_get_pose'
+        },
+        {
+          kind: 'BLOCK',
+          type: 'niryo_one_get_pose_quat'
+        },
+        {
+          kind: 'BLOCK',
+          type: 'niryo_one_shift_pose'
+        },
+        {
+          kind: 'BLOCK',
+          type: 'niryo_one_shift_linear_pose'
+        },
+        {
+          kind: 'BLOCK',
+          type: 'niryo_one_set_arm_max_speed'
         },
         {
           kind: 'BLOCK',
@@ -1804,15 +2539,55 @@ const TOOLBOX = {
         },
         {
           kind: 'BLOCK',
-          type: 'niryo_one_move_pose_from_pose'
-        },
-        {
-          kind: 'BLOCK',
           type: 'niryo_one_pick_from_pose'
         },
         {
           kind: 'BLOCK',
           type: 'niryo_one_place_from_pose'
+        },
+        // {
+        //   kind: 'BLOCK',
+        //   type: 'niryo_one_pick_and_place'
+        // },
+        {
+          kind: 'BLOCK',
+          type: 'niryo_one_jog_joints'
+        },
+        {
+          kind: 'BLOCK',
+          type: 'niryo_one_jog_pose'
+        },
+        {
+          kind: 'BLOCK',
+          type: 'niryo_one_move_to_home_pose'
+        },
+        {
+          kind: 'BLOCK',
+          type: 'niryo_one_sleep'
+        },
+        {
+          kind: 'BLOCK',
+          type: 'niryo_one_forward_kinematics'
+        },
+        {
+          kind: 'BLOCK',
+          type: 'niryo_one_inverse_kinematics'
+        },
+        {
+          kind: 'BLOCK',
+          type: 'niryo_one_get_saved_pose'
+        },
+        {
+          kind: 'BLOCK',
+          type: 'niryo_one_save_pose'
+        },
+        {
+          kind: 'BLOCK',
+          type: 'niryo_one_delete_pose'
+        },
+        {
+          kind: 'BLOCK',
+          type: 'niryo_one_get_saved_pose_list'
         },
         {
           kind: 'BLOCK',
@@ -1884,7 +2659,7 @@ const TOOLBOX = {
         },
         {
           kind: 'BLOCK',
-          type: 'niryo_one_sleep'
+          type: 'niryo_one_wait'
         },
         {
           kind: 'BLOCK',

--- a/src/niryo_one_python_generators.js
+++ b/src/niryo_one_python_generators.js
@@ -1645,11 +1645,12 @@ Blockly.Blocks['niryo_one_vision_is_object_detected'] = {
 
 Blockly.Blocks['niryo_one_get_img_compressed'] = {
   init: function () {
-    this.appendDummyInput()
-      .appendField('Get image compressed')
+    this.appendDummyInput().appendField('Get image compressed');
     this.setOutput(true, 'String');
     this.setColour(vision_color);
-    this.setTooltip('Get image from video stream in a compressed format. Returns string containing a JPEG compressed image.');
+    this.setTooltip(
+      'Get image from video stream in a compressed format. Returns string containing a JPEG compressed image.'
+    );
     this.setHelpUrl('');
   }
 };
@@ -1662,7 +1663,9 @@ Blockly.Blocks['niryo_one_set_brightness'] = {
     this.setPreviousStatement(true, null);
     this.setNextStatement(true, null);
     this.setColour(vision_color);
-    this.setTooltip('Modify video stream brightness.How much to adjust the brightness. 0.5 will give a darkened image, 1 will give the original image while 2 will enhance the brightness by a factor of 2.');
+    this.setTooltip(
+      'Modify video stream brightness.How much to adjust the brightness. 0.5 will give a darkened image, 1 will give the original image while 2 will enhance the brightness by a factor of 2.'
+    );
     this.setHelpUrl('');
   }
 };
@@ -1675,7 +1678,9 @@ Blockly.Blocks['niryo_one_set_contrast'] = {
     this.setPreviousStatement(true, null);
     this.setNextStatement(true, null);
     this.setColour(vision_color);
-    this.setTooltip('Modify video stream contrast. While a factor of 1 gives original image. Making the factor towards 0 makes the image greyer, while factor>1 increases the contrast of the image.');
+    this.setTooltip(
+      'Modify video stream contrast. While a factor of 1 gives original image. Making the factor towards 0 makes the image greyer, while factor>1 increases the contrast of the image.'
+    );
     this.setHelpUrl('');
   }
 };
@@ -1688,18 +1693,21 @@ Blockly.Blocks['niryo_one_set_saturation'] = {
     this.setPreviousStatement(true, null);
     this.setNextStatement(true, null);
     this.setColour(vision_color);
-    this.setTooltip('Modify video stream saturation. How much to adjust the saturation. 0 will give a black and white image, 1 will give the original image while 2 will enhance the saturation by a factor of 2.');
+    this.setTooltip(
+      'Modify video stream saturation. How much to adjust the saturation. 0 will give a black and white image, 1 will give the original image while 2 will enhance the saturation by a factor of 2.'
+    );
     this.setHelpUrl('');
   }
 };
 
 Blockly.Blocks['niryo_one_get_image_parameters'] = {
   init: function () {
-    this.appendDummyInput()
-      .appendField('Get image parameters');
+    this.appendDummyInput().appendField('Get image parameters');
     this.setOutput(true, 'String');
     this.setColour(vision_color);
-    this.setTooltip('Get last stream image parameters: Brightness factor, Contrast factor, Saturation factor.');
+    this.setTooltip(
+      'Get last stream image parameters: Brightness factor, Contrast factor, Saturation factor.'
+    );
     this.setHelpUrl('');
   }
 };
@@ -1709,29 +1717,22 @@ Blockly.Blocks['niryo_one_get_target_pose_from_rel'] = {
     this.appendDummyInput().appendField('Get robot pose relative to pose');
     this.appendDummyInput()
       .appendField('x')
-      .appendField(
-        new Blockly.FieldNumber(0, 0, 1, 0.001),
-        'POSE_X'
-      )
+      .appendField(new Blockly.FieldNumber(0, 0, 1, 0.001), 'POSE_X')
       .appendField('y')
-      .appendField(
-        new Blockly.FieldNumber(0, 0, 1, 0.001),
-        'POSE_Y'
-      )
+      .appendField(new Blockly.FieldNumber(0, 0, 1, 0.001), 'POSE_Y')
       .appendField('z')
-      .appendField(
-        new Blockly.FieldNumber(0, 0, 1, 0.001),
-        'POSE_Z'
-      )
+      .appendField(new Blockly.FieldNumber(0, 0, 1, 0.001), 'POSE_Z');
     this.appendValueInput('HEIGHT_OFFSET')
       .setCheck('Number')
       .appendField('with heigh offset');
-   this.appendValueInput('WORKSPACE_NAME')
+    this.appendValueInput('WORKSPACE_NAME')
       .setCheck('String')
       .appendField('in workspace');
     this.setOutput(true, 'niryo_one_pose');
     this.setColour(vision_color);
-    this.setTooltip('Given a pose (x_rel, y_rel, yaw_rel) relative to a workspace, this function returns the robot pose in which the current tool will be able to pick an object at this pose. The height_offset argument (in m) defines how high the tool will hover over the workspace. If height_offset = 0, the tool will nearly touch the workspace.');
+    this.setTooltip(
+      'Given a pose (x_rel, y_rel, yaw_rel) relative to a workspace, this function returns the robot pose in which the current tool will be able to pick an object at this pose. The height_offset argument (in m) defines how high the tool will hover over the workspace. If height_offset = 0, the tool will nearly touch the workspace.'
+    );
     this.setHelpUrl('');
   }
 };
@@ -1747,13 +1748,15 @@ Blockly.Blocks['niryo_one_get_target_pose_from_cam'] = {
       .appendField('with height offset');
     this.appendValueInput('SHAPE')
       .setCheck('niryo_one_vision_shape')
-      .appendField('for object of shape')
+      .appendField('for object of shape');
     this.appendValueInput('COLOR')
       .setCheck('niryo_one_vision_color')
       .appendField('and color');
     this.setOutput(true, 'niryo_one_pose');
     this.setColour(vision_color);
-    this.setTooltip('First detects the specified object using the camera and then returns the robot pose in which the object can be picked with the current tool');
+    this.setTooltip(
+      'First detects the specified object using the camera and then returns the robot pose in which the object can be picked with the current tool'
+    );
     this.setHelpUrl('');
   }
 };
@@ -1769,13 +1772,15 @@ Blockly.Blocks['niryo_one_move_to_object'] = {
       .appendField('with height offset');
     this.appendValueInput('SHAPE')
       .setCheck('niryo_one_vision_shape')
-      .appendField('for object of shape')
+      .appendField('for object of shape');
     this.appendValueInput('COLOR')
       .setCheck('niryo_one_vision_color')
       .appendField('and color');
     this.setOutput(true, 'niryo_one_pose');
     this.setColour(vision_color);
-    this.setTooltip('Same as get_target_pose_from_cam but directly moves to this position');
+    this.setTooltip(
+      'Same as get_target_pose_from_cam but directly moves to this position'
+    );
     this.setHelpUrl('');
   }
 };
@@ -1785,7 +1790,9 @@ Blockly.Blocks['niryo_one_get_camera_intrinsics'] = {
     this.appendDummyInput().appendField('Get camera intrinsics');
     this.setOutput(true, 'String');
     this.setColour(vision_color);
-    this.setTooltip('Get calibration object: camera intrinsics, distortions coefficients');
+    this.setTooltip(
+      'Get calibration object: camera intrinsics, distortions coefficients'
+    );
     this.setHelpUrl('');
   }
 };
@@ -1795,8 +1802,8 @@ Blockly.Blocks['niryo_one_save_workspace_from_robot_poses'] = {
     this.appendValueInput('WORKSPACE_NAME')
       .setCheck('String')
       .appendField('Save workspace under name');
-    this.appendDummyInput().appendField('from the 4 corners defined by')
-    this.appendDummyInput().appendField('\n')
+    this.appendDummyInput().appendField('from the 4 corners defined by');
+    this.appendDummyInput().appendField('\n');
     this.appendValueInput('POSE_1')
       .setCheck('niryo_one_pose')
       .appendField('pose 1');
@@ -1812,7 +1819,9 @@ Blockly.Blocks['niryo_one_save_workspace_from_robot_poses'] = {
     this.setPreviousStatement(true, null);
     this.setNextStatement(true, null);
     this.setColour(vision_color);
-    this.setTooltip('Save workspace by giving the poses of the robot to point its 4 corners with the calibration Tip. Corners should be in the good order. Markers’ pose will be deduced from these poses');
+    this.setTooltip(
+      'Save workspace by giving the poses of the robot to point its 4 corners with the calibration Tip. Corners should be in the good order. Markers’ pose will be deduced from these poses'
+    );
     this.setHelpUrl('');
   }
 };
@@ -1822,8 +1831,8 @@ Blockly.Blocks['niryo_one_save_workspace_from_points'] = {
     this.appendValueInput('WORKSPACE_NAME')
       .setCheck('String')
       .appendField('Save workspace under name');
-    this.appendDummyInput().appendField('from the 4 corners defined by')
-    this.appendDummyInput().appendField('\n')
+    this.appendDummyInput().appendField('from the 4 corners defined by');
+    this.appendDummyInput().appendField('\n');
     this.appendValueInput('POINT_1')
       .setCheck('niryo_one_point')
       .appendField('point 1');
@@ -1839,7 +1848,9 @@ Blockly.Blocks['niryo_one_save_workspace_from_points'] = {
     this.setPreviousStatement(true, null);
     this.setNextStatement(true, null);
     this.setColour(vision_color);
-    this.setTooltip('Save workspace by giving the points of worskpace’s 4 corners. Points are written as [x, y, z] Corners should be in the good order.');
+    this.setTooltip(
+      'Save workspace by giving the points of worskpace’s 4 corners. Points are written as [x, y, z] Corners should be in the good order.'
+    );
     this.setHelpUrl('');
   }
 };
@@ -3551,7 +3562,7 @@ BlocklyPy['niryo_one_get_target_pose_from_rel'] = function (block) {
   var height_offset_value =
     BlocklyPy.valueToCode(block, 'HEIGHT_OFFSET', BlocklyPy.ORDER_ATOMIC) ||
     '(0)';
-    height_offset_value = height_offset_value.replace('(', '').replace(')', '');
+  height_offset_value = height_offset_value.replace('(', '').replace(')', '');
 
   var workspace_name =
     BlocklyPy.valueToCode(block, 'WORKSPACE_NAME', BlocklyPy.ORDER_ATOMIC) ||
@@ -3559,8 +3570,11 @@ BlocklyPy['niryo_one_get_target_pose_from_rel'] = function (block) {
   workspace_name = workspace_name.replace('(', '').replace(')', '');
 
   var code =
-    'n.get_target_pose_from_rel(' + workspace_name + ', ' +
-    height_offset_value + ', ' +
+    'n.get_target_pose_from_rel(' +
+    workspace_name +
+    ', ' +
+    height_offset_value +
+    ', ' +
     value_x +
     ', ' +
     value_y +
@@ -3579,23 +3593,29 @@ BlocklyPy['niryo_one_get_target_pose_from_cam'] = function (block) {
   var height_offset_value =
     BlocklyPy.valueToCode(block, 'HEIGHT_OFFSET', BlocklyPy.ORDER_ATOMIC) ||
     '(0)';
-    height_offset_value = height_offset_value.replace('(', '').replace(')', '');
+  height_offset_value = height_offset_value.replace('(', '').replace(')', '');
 
   // Color (int) value (see g_shape_values at top of this file)
   var value_color =
-    BlocklyPy.valueToCode(block, 'COLOR', BlocklyPy.ORDER_ATOMIC) ||
-    '(0)';
+    BlocklyPy.valueToCode(block, 'COLOR', BlocklyPy.ORDER_ATOMIC) || '(0)';
   value_color = value_color.replace('(', '').replace(')', '');
 
   // Shape (int) value (see g_shape_values at top of this file)
   var value_shape =
-    BlocklyPy.valueToCode(block, 'SHAPE', BlocklyPy.ORDER_ATOMIC) ||
-    '(0)';
+    BlocklyPy.valueToCode(block, 'SHAPE', BlocklyPy.ORDER_ATOMIC) || '(0)';
   value_shape = value_shape.replace('(', '').replace(')', '');
 
-  var code = 'n.get_target_pose_from_cam(' + workspace_name + ', ' +  height_offset_value + ', ' + value_color + ', ' + value_shape + ')\n';
+  var code =
+    'n.get_target_pose_from_cam(' +
+    workspace_name +
+    ', ' +
+    height_offset_value +
+    ', ' +
+    value_color +
+    ', ' +
+    value_shape +
+    ')\n';
   return [code, BlocklyPy.ORDER_NONE];
-  
 };
 
 BlocklyPy['niryo_one_move_to_object'] = function (block) {
@@ -3607,23 +3627,29 @@ BlocklyPy['niryo_one_move_to_object'] = function (block) {
   var height_offset_value =
     BlocklyPy.valueToCode(block, 'HEIGHT_OFFSET', BlocklyPy.ORDER_ATOMIC) ||
     '(0)';
-    height_offset_value = height_offset_value.replace('(', '').replace(')', '');
+  height_offset_value = height_offset_value.replace('(', '').replace(')', '');
 
   // Color (int) value (see g_shape_values at top of this file)
   var value_color =
-    BlocklyPy.valueToCode(block, 'COLOR', BlocklyPy.ORDER_ATOMIC) ||
-    '(0)';
+    BlocklyPy.valueToCode(block, 'COLOR', BlocklyPy.ORDER_ATOMIC) || '(0)';
   value_color = value_color.replace('(', '').replace(')', '');
 
   // Shape (int) value (see g_shape_values at top of this file)
   var value_shape =
-    BlocklyPy.valueToCode(block, 'SHAPE', BlocklyPy.ORDER_ATOMIC) ||
-    '(0)';
+    BlocklyPy.valueToCode(block, 'SHAPE', BlocklyPy.ORDER_ATOMIC) || '(0)';
   value_shape = value_shape.replace('(', '').replace(')', '');
 
-  var code = 'n.move_to_object(' + workspace_name + ', ' +  height_offset_value + ', ' + value_color + ', ' + value_shape + ')\n';
+  var code =
+    'n.move_to_object(' +
+    workspace_name +
+    ', ' +
+    height_offset_value +
+    ', ' +
+    value_color +
+    ', ' +
+    value_shape +
+    ')\n';
   return [code, BlocklyPy.ORDER_NONE];
-  
 };
 
 BlocklyPy['niryo_one_get_camera_intrinsics'] = function (block) {
@@ -3631,7 +3657,7 @@ BlocklyPy['niryo_one_get_camera_intrinsics'] = function (block) {
   return code;
 };
 
-BlocklyPy['niryo_one_save_workspace_from_robot_poses']  = function (block) {
+BlocklyPy['niryo_one_save_workspace_from_robot_poses'] = function (block) {
   var workspace_name =
     BlocklyPy.valueToCode(block, 'WORKSPACE_NAME', BlocklyPy.ORDER_ATOMIC) ||
     '(0)';
@@ -3665,15 +3691,22 @@ BlocklyPy['niryo_one_save_workspace_from_robot_poses']  = function (block) {
   );
   value_pose_4 = value_pose_4.replace('(', '').replace(')', '');
 
-  var code = 'n.save_workspace_from_robot_poses(' + workspace_name + ', ' +
-  value_pose_1 + ', ' + 
-  value_pose_2 + ', ' + 
-  value_pose_3 + ', ' + 
-  value_pose_4  + ')\n';
+  var code =
+    'n.save_workspace_from_robot_poses(' +
+    workspace_name +
+    ', ' +
+    value_pose_1 +
+    ', ' +
+    value_pose_2 +
+    ', ' +
+    value_pose_3 +
+    ', ' +
+    value_pose_4 +
+    ')\n';
   return code;
 };
 
-BlocklyPy['niryo_one_save_workspace_from_points']  = function (block) {
+BlocklyPy['niryo_one_save_workspace_from_points'] = function (block) {
   var workspace_name =
     BlocklyPy.valueToCode(block, 'WORKSPACE_NAME', BlocklyPy.ORDER_ATOMIC) ||
     '(0)';
@@ -3707,15 +3740,22 @@ BlocklyPy['niryo_one_save_workspace_from_points']  = function (block) {
   );
   value_point_4 = value_point_4.replace('(', '').replace(')', '');
 
-  var code = 'n.save_workspace_from_points(' + workspace_name + ', ' +
-  value_point_1 + ', ' + 
-  value_point_2 + ', ' + 
-  value_point_3 + ', ' + 
-  value_point_4  + ')\n';
+  var code =
+    'n.save_workspace_from_points(' +
+    workspace_name +
+    ', ' +
+    value_point_1 +
+    ', ' +
+    value_point_2 +
+    ', ' +
+    value_point_3 +
+    ', ' +
+    value_point_4 +
+    ')\n';
   return code;
 };
 
-BlocklyPy['niryo_one_delete_workspace']  = function (block) {
+BlocklyPy['niryo_one_delete_workspace'] = function (block) {
   var workspace_name =
     BlocklyPy.valueToCode(block, 'WORKSPACE_NAME', BlocklyPy.ORDER_ATOMIC) ||
     '(0)';

--- a/src/niryo_one_python_generators.js
+++ b/src/niryo_one_python_generators.js
@@ -35,10 +35,10 @@ var movement_color = '#4f87c0';
 var io_color = '#c05150';
 var tool_color = '#bf964b';
 var utility_color = '#bead76';
-var vision_color = '#546e7a';
+var vision_color = '#4B0082';
 var conveyor_color = '#00838f';
 var sound_color = '#FFC0CB';
-var frames_color = '#4B0082';
+var frames_color = '#546e7a';
 var led_color = '65c368';
 var trajectory_color = '#9370DB';
 
@@ -1640,6 +1640,242 @@ Blockly.Blocks['niryo_one_vision_is_object_detected'] = {
       'Detect is there is an object of SHAPE / COLOR in the WORKSPACE given.'
     );
     this.setInputsInline(false);
+  }
+};
+
+Blockly.Blocks['niryo_one_get_img_compressed'] = {
+  init: function () {
+    this.appendDummyInput()
+      .appendField('Get image compressed')
+    this.setOutput(true, 'String');
+    this.setColour(vision_color);
+    this.setTooltip('Get image from video stream in a compressed format. Returns string containing a JPEG compressed image.');
+    this.setHelpUrl('');
+  }
+};
+
+Blockly.Blocks['niryo_one_set_brightness'] = {
+  init: function () {
+    this.appendValueInput('BRIGHTNESS')
+      .setCheck('Number')
+      .appendField('Set brightness to');
+    this.setPreviousStatement(true, null);
+    this.setNextStatement(true, null);
+    this.setColour(vision_color);
+    this.setTooltip('Modify video stream brightness.How much to adjust the brightness. 0.5 will give a darkened image, 1 will give the original image while 2 will enhance the brightness by a factor of 2.');
+    this.setHelpUrl('');
+  }
+};
+
+Blockly.Blocks['niryo_one_set_contrast'] = {
+  init: function () {
+    this.appendValueInput('CONTRAST')
+      .setCheck('Number')
+      .appendField('Set contrast to');
+    this.setPreviousStatement(true, null);
+    this.setNextStatement(true, null);
+    this.setColour(vision_color);
+    this.setTooltip('Modify video stream contrast. While a factor of 1 gives original image. Making the factor towards 0 makes the image greyer, while factor>1 increases the contrast of the image.');
+    this.setHelpUrl('');
+  }
+};
+
+Blockly.Blocks['niryo_one_set_saturation'] = {
+  init: function () {
+    this.appendValueInput('SATURATION')
+      .setCheck('Number')
+      .appendField('Set saturation to');
+    this.setPreviousStatement(true, null);
+    this.setNextStatement(true, null);
+    this.setColour(vision_color);
+    this.setTooltip('Modify video stream saturation. How much to adjust the saturation. 0 will give a black and white image, 1 will give the original image while 2 will enhance the saturation by a factor of 2.');
+    this.setHelpUrl('');
+  }
+};
+
+Blockly.Blocks['niryo_one_get_image_parameters'] = {
+  init: function () {
+    this.appendDummyInput()
+      .appendField('Get image parameters');
+    this.setOutput(true, 'String');
+    this.setColour(vision_color);
+    this.setTooltip('Get last stream image parameters: Brightness factor, Contrast factor, Saturation factor.');
+    this.setHelpUrl('');
+  }
+};
+
+Blockly.Blocks['niryo_one_get_target_pose_from_rel'] = {
+  init: function () {
+    this.appendDummyInput().appendField('Get robot pose relative to pose');
+    this.appendDummyInput()
+      .appendField('x')
+      .appendField(
+        new Blockly.FieldNumber(0, 0, 1, 0.001),
+        'POSE_X'
+      )
+      .appendField('y')
+      .appendField(
+        new Blockly.FieldNumber(0, 0, 1, 0.001),
+        'POSE_Y'
+      )
+      .appendField('z')
+      .appendField(
+        new Blockly.FieldNumber(0, 0, 1, 0.001),
+        'POSE_Z'
+      )
+    this.appendValueInput('HEIGHT_OFFSET')
+      .setCheck('Number')
+      .appendField('with heigh offset');
+   this.appendValueInput('WORKSPACE_NAME')
+      .setCheck('String')
+      .appendField('in workspace');
+    this.setOutput(true, 'niryo_one_pose');
+    this.setColour(vision_color);
+    this.setTooltip('Given a pose (x_rel, y_rel, yaw_rel) relative to a workspace, this function returns the robot pose in which the current tool will be able to pick an object at this pose. The height_offset argument (in m) defines how high the tool will hover over the workspace. If height_offset = 0, the tool will nearly touch the workspace.');
+    this.setHelpUrl('');
+  }
+};
+
+Blockly.Blocks['niryo_one_get_target_pose_from_cam'] = {
+  init: function () {
+    this.appendDummyInput().appendField('Get target pose from camera');
+    this.appendValueInput('WORKSPACE_NAME')
+      .setCheck('String')
+      .appendField('in workspace');
+    this.appendValueInput('HEIGHT_OFFSET')
+      .setCheck('Number')
+      .appendField('with height offset');
+    this.appendValueInput('SHAPE')
+      .setCheck('niryo_one_vision_shape')
+      .appendField('for object of shape')
+    this.appendValueInput('COLOR')
+      .setCheck('niryo_one_vision_color')
+      .appendField('and color');
+    this.setOutput(true, 'niryo_one_pose');
+    this.setColour(vision_color);
+    this.setTooltip('First detects the specified object using the camera and then returns the robot pose in which the object can be picked with the current tool');
+    this.setHelpUrl('');
+  }
+};
+
+Blockly.Blocks['niryo_one_move_to_object'] = {
+  init: function () {
+    this.appendDummyInput().appendField('Detect target and move to it');
+    this.appendValueInput('WORKSPACE_NAME')
+      .setCheck('String')
+      .appendField('in workspace');
+    this.appendValueInput('HEIGHT_OFFSET')
+      .setCheck('Number')
+      .appendField('with height offset');
+    this.appendValueInput('SHAPE')
+      .setCheck('niryo_one_vision_shape')
+      .appendField('for object of shape')
+    this.appendValueInput('COLOR')
+      .setCheck('niryo_one_vision_color')
+      .appendField('and color');
+    this.setOutput(true, 'niryo_one_pose');
+    this.setColour(vision_color);
+    this.setTooltip('Same as get_target_pose_from_cam but directly moves to this position');
+    this.setHelpUrl('');
+  }
+};
+
+Blockly.Blocks['niryo_one_get_camera_intrinsics'] = {
+  init: function () {
+    this.appendDummyInput().appendField('Get camera intrinsics');
+    this.setOutput(true, 'String');
+    this.setColour(vision_color);
+    this.setTooltip('Get calibration object: camera intrinsics, distortions coefficients');
+    this.setHelpUrl('');
+  }
+};
+
+Blockly.Blocks['niryo_one_save_workspace_from_robot_poses'] = {
+  init: function () {
+    this.appendValueInput('WORKSPACE_NAME')
+      .setCheck('String')
+      .appendField('Save workspace under name');
+    this.appendDummyInput().appendField('from the 4 corners defined by')
+    this.appendDummyInput().appendField('\n')
+    this.appendValueInput('POSE_1')
+      .setCheck('niryo_one_pose')
+      .appendField('pose 1');
+    this.appendValueInput('POSE_2')
+      .setCheck('niryo_one_pose')
+      .appendField('pose 2');
+    this.appendValueInput('POSE_3')
+      .setCheck('niryo_one_pose')
+      .appendField('pose 3');
+    this.appendValueInput('POSE_4')
+      .setCheck('niryo_one_pose')
+      .appendField('and pose 4');
+    this.setPreviousStatement(true, null);
+    this.setNextStatement(true, null);
+    this.setColour(vision_color);
+    this.setTooltip('Save workspace by giving the poses of the robot to point its 4 corners with the calibration Tip. Corners should be in the good order. Markers’ pose will be deduced from these poses');
+    this.setHelpUrl('');
+  }
+};
+
+Blockly.Blocks['niryo_one_save_workspace_from_points'] = {
+  init: function () {
+    this.appendValueInput('WORKSPACE_NAME')
+      .setCheck('String')
+      .appendField('Save workspace under name');
+    this.appendDummyInput().appendField('from the 4 corners defined by')
+    this.appendDummyInput().appendField('\n')
+    this.appendValueInput('POINT_1')
+      .setCheck('niryo_one_point')
+      .appendField('point 1');
+    this.appendValueInput('POINT_2')
+      .setCheck('niryo_one_point')
+      .appendField('point 2');
+    this.appendValueInput('POINT_3')
+      .setCheck('niryo_one_point')
+      .appendField('point 3');
+    this.appendValueInput('POINT_4')
+      .setCheck('niryo_one_point')
+      .appendField('and point 4');
+    this.setPreviousStatement(true, null);
+    this.setNextStatement(true, null);
+    this.setColour(vision_color);
+    this.setTooltip('Save workspace by giving the points of worskpace’s 4 corners. Points are written as [x, y, z] Corners should be in the good order.');
+    this.setHelpUrl('');
+  }
+};
+
+Blockly.Blocks['niryo_one_delete_workspace'] = {
+  init: function () {
+    this.appendValueInput('WORKSPACE_NAME')
+      .setCheck('String')
+      .appendField('Delete workspace');
+    this.setPreviousStatement(true, null);
+    this.setNextStatement(true, null);
+    this.setColour(vision_color);
+    this.setTooltip('Delete workspace');
+    this.setHelpUrl('');
+  }
+};
+
+Blockly.Blocks['niryo_one_get_workspace_ratio'] = {
+  init: function () {
+    this.appendValueInput('WORKSPACE_NAME')
+      .setCheck('String')
+      .appendField('Get ratio of workspace');
+    this.setOutput(true, 'Number');
+    this.setColour(vision_color);
+    this.setTooltip('Get workspace ratio');
+    this.setHelpUrl('');
+  }
+};
+
+Blockly.Blocks['niryo_one_get_workspace_list'] = {
+  init: function () {
+    this.appendDummyInput().appendField('Get workspace list');
+    this.setOutput(true, 'any');
+    this.setColour(vision_color);
+    this.setTooltip('Get list of workspaces’ name store in robot’s memory');
+    this.setHelpUrl('');
   }
 };
 
@@ -3262,6 +3498,248 @@ BlocklyPy['niryo_one_vision_is_object_detected'] = function (block) {
   return [code, BlocklyPy.ORDER_NONE];
 };
 
+BlocklyPy['niryo_one_get_img_compressed'] = function (block) {
+  var code = 'n.get_img_compressed()\n';
+  return [code, BlocklyPy.ORDER_NONE];
+};
+
+BlocklyPy['niryo_one_set_brightness'] = function (block) {
+  var value_brightness =
+    BlocklyPy.valueToCode(block, 'BRIGHTNESS', BlocklyPy.ORDER_ATOMIC) || '0';
+  value_brightness = value_brightness.replace('(', '').replace(')', '');
+
+  var code = 'n.set_brightness(' + value_brightness + ')\n';
+  return code;
+};
+
+BlocklyPy['niryo_one_set_contrast'] = function (block) {
+  var value_contrast =
+    BlocklyPy.valueToCode(block, 'CONTRAST', BlocklyPy.ORDER_ATOMIC) || '0';
+  value_contrast = value_contrast.replace('(', '').replace(')', '');
+
+  var code = 'n.set_contrast(' + value_contrast + ')\n';
+  return code;
+};
+
+BlocklyPy['niryo_one_set_saturation'] = function (block) {
+  var value_saturation =
+    BlocklyPy.valueToCode(block, 'SATURATION', BlocklyPy.ORDER_ATOMIC) || '0';
+  value_saturation = value_saturation.replace('(', '').replace(')', '');
+
+  var code = 'n.set_saturation(' + value_saturation + ')\n';
+  return code;
+};
+
+BlocklyPy['niryo_one_get_image_parameters'] = function (block) {
+  var code = 'n.get_image_parameters()\n';
+  return [code, BlocklyPy.ORDER_NONE];
+};
+
+BlocklyPy['niryo_one_get_target_pose_from_rel'] = function (block) {
+  var value_x =
+    BlocklyPy.valueToCode(block, 'POSE_X', BlocklyPy.ORDER_ATOMIC) || '0';
+  value_x = value_x.replace('(', '').replace(')', '');
+
+  var value_y =
+    BlocklyPy.valueToCode(block, 'POSE_Y', BlocklyPy.ORDER_ATOMIC) || '0';
+  value_y = value_y.replace('(', '').replace(')', '');
+
+  var value_z =
+    BlocklyPy.valueToCode(block, 'POSE_Z', BlocklyPy.ORDER_ATOMIC) || '0';
+  value_z = value_z.replace('(', '').replace(')', '');
+
+  var height_offset_value =
+    BlocklyPy.valueToCode(block, 'HEIGHT_OFFSET', BlocklyPy.ORDER_ATOMIC) ||
+    '(0)';
+    height_offset_value = height_offset_value.replace('(', '').replace(')', '');
+
+  var workspace_name =
+    BlocklyPy.valueToCode(block, 'WORKSPACE_NAME', BlocklyPy.ORDER_ATOMIC) ||
+    '(0)';
+  workspace_name = workspace_name.replace('(', '').replace(')', '');
+
+  var code =
+    'n.get_target_pose_from_rel(' + workspace_name + ', ' +
+    height_offset_value + ', ' +
+    value_x +
+    ', ' +
+    value_y +
+    ', ' +
+    value_z +
+    ')\n';
+  return [code, BlocklyPy.ORDER_NONE];
+};
+
+BlocklyPy['niryo_one_get_target_pose_from_cam'] = function (block) {
+  var workspace_name =
+    BlocklyPy.valueToCode(block, 'WORKSPACE_NAME', BlocklyPy.ORDER_ATOMIC) ||
+    '(0)';
+  workspace_name = workspace_name.replace('(', '').replace(')', '');
+
+  var height_offset_value =
+    BlocklyPy.valueToCode(block, 'HEIGHT_OFFSET', BlocklyPy.ORDER_ATOMIC) ||
+    '(0)';
+    height_offset_value = height_offset_value.replace('(', '').replace(')', '');
+
+  // Color (int) value (see g_shape_values at top of this file)
+  var value_color =
+    BlocklyPy.valueToCode(block, 'COLOR', BlocklyPy.ORDER_ATOMIC) ||
+    '(0)';
+  value_color = value_color.replace('(', '').replace(')', '');
+
+  // Shape (int) value (see g_shape_values at top of this file)
+  var value_shape =
+    BlocklyPy.valueToCode(block, 'SHAPE', BlocklyPy.ORDER_ATOMIC) ||
+    '(0)';
+  value_shape = value_shape.replace('(', '').replace(')', '');
+
+  var code = 'n.get_target_pose_from_cam(' + workspace_name + ', ' +  height_offset_value + ', ' + value_color + ', ' + value_shape + ')\n';
+  return [code, BlocklyPy.ORDER_NONE];
+  
+};
+
+BlocklyPy['niryo_one_move_to_object'] = function (block) {
+  var workspace_name =
+    BlocklyPy.valueToCode(block, 'WORKSPACE_NAME', BlocklyPy.ORDER_ATOMIC) ||
+    '(0)';
+  workspace_name = workspace_name.replace('(', '').replace(')', '');
+
+  var height_offset_value =
+    BlocklyPy.valueToCode(block, 'HEIGHT_OFFSET', BlocklyPy.ORDER_ATOMIC) ||
+    '(0)';
+    height_offset_value = height_offset_value.replace('(', '').replace(')', '');
+
+  // Color (int) value (see g_shape_values at top of this file)
+  var value_color =
+    BlocklyPy.valueToCode(block, 'COLOR', BlocklyPy.ORDER_ATOMIC) ||
+    '(0)';
+  value_color = value_color.replace('(', '').replace(')', '');
+
+  // Shape (int) value (see g_shape_values at top of this file)
+  var value_shape =
+    BlocklyPy.valueToCode(block, 'SHAPE', BlocklyPy.ORDER_ATOMIC) ||
+    '(0)';
+  value_shape = value_shape.replace('(', '').replace(')', '');
+
+  var code = 'n.move_to_object(' + workspace_name + ', ' +  height_offset_value + ', ' + value_color + ', ' + value_shape + ')\n';
+  return [code, BlocklyPy.ORDER_NONE];
+  
+};
+
+BlocklyPy['niryo_one_get_camera_intrinsics'] = function (block) {
+  var code = 'n.get_camera_intrinsics()\n';
+  return code;
+};
+
+BlocklyPy['niryo_one_save_workspace_from_robot_poses']  = function (block) {
+  var workspace_name =
+    BlocklyPy.valueToCode(block, 'WORKSPACE_NAME', BlocklyPy.ORDER_ATOMIC) ||
+    '(0)';
+  workspace_name = workspace_name.replace('(', '').replace(')', '');
+
+  var value_pose_1 = BlocklyPy.valueToCode(
+    block,
+    'POSE_1',
+    BlocklyPy.ORDER_ATOMIC
+  );
+  value_pose_1 = value_pose_1.replace('(', '').replace(')', '');
+
+  var value_pose_2 = BlocklyPy.valueToCode(
+    block,
+    'POSE_2',
+    BlocklyPy.ORDER_ATOMIC
+  );
+  value_pose_2 = value_pose_2.replace('(', '').replace(')', '');
+
+  var value_pose_3 = BlocklyPy.valueToCode(
+    block,
+    'POSE_3',
+    BlocklyPy.ORDER_ATOMIC
+  );
+  value_pose_3 = value_pose_3.replace('(', '').replace(')', '');
+
+  var value_pose_4 = BlocklyPy.valueToCode(
+    block,
+    'POSE_4',
+    BlocklyPy.ORDER_ATOMIC
+  );
+  value_pose_4 = value_pose_4.replace('(', '').replace(')', '');
+
+  var code = 'n.save_workspace_from_robot_poses(' + workspace_name + ', ' +
+  value_pose_1 + ', ' + 
+  value_pose_2 + ', ' + 
+  value_pose_3 + ', ' + 
+  value_pose_4  + ')\n';
+  return code;
+};
+
+BlocklyPy['niryo_one_save_workspace_from_points']  = function (block) {
+  var workspace_name =
+    BlocklyPy.valueToCode(block, 'WORKSPACE_NAME', BlocklyPy.ORDER_ATOMIC) ||
+    '(0)';
+  workspace_name = workspace_name.replace('(', '').replace(')', '');
+
+  var value_point_1 = BlocklyPy.valueToCode(
+    block,
+    'POINT_1',
+    BlocklyPy.ORDER_ATOMIC
+  );
+  value_point_1 = value_point_1.replace('(', '').replace(')', '');
+
+  var value_point_2 = BlocklyPy.valueToCode(
+    block,
+    'POINT_2',
+    BlocklyPy.ORDER_ATOMIC
+  );
+  value_point_2 = value_point_2.replace('(', '').replace(')', '');
+
+  var value_point_3 = BlocklyPy.valueToCode(
+    block,
+    'POINT_3',
+    BlocklyPy.ORDER_ATOMIC
+  );
+  value_point_3 = value_point_3.replace('(', '').replace(')', '');
+
+  var value_point_4 = BlocklyPy.valueToCode(
+    block,
+    'POINT_4',
+    BlocklyPy.ORDER_ATOMIC
+  );
+  value_point_4 = value_point_4.replace('(', '').replace(')', '');
+
+  var code = 'n.save_workspace_from_points(' + workspace_name + ', ' +
+  value_point_1 + ', ' + 
+  value_point_2 + ', ' + 
+  value_point_3 + ', ' + 
+  value_point_4  + ')\n';
+  return code;
+};
+
+BlocklyPy['niryo_one_delete_workspace']  = function (block) {
+  var workspace_name =
+    BlocklyPy.valueToCode(block, 'WORKSPACE_NAME', BlocklyPy.ORDER_ATOMIC) ||
+    '(0)';
+  workspace_name = workspace_name.replace('(', '').replace(')', '');
+
+  var code = 'n.delete_workspace(' + workspace_name + ')\n';
+  return code;
+};
+
+BlocklyPy['niryo_one_get_workspace_ratio'] = function (block) {
+  var workspace_name =
+    BlocklyPy.valueToCode(block, 'WORKSPACE_NAME', BlocklyPy.ORDER_ATOMIC) ||
+    '(0)';
+  workspace_name = workspace_name.replace('(', '').replace(')', '');
+
+  var code = 'n.get_workspace_ratio(' + workspace_name + ')\n';
+  return [code, BlocklyPy.ORDER_NONE];
+};
+
+BlocklyPy['niryo_one_get_workspace_list'] = function (block) {
+  var code = 'n.get_workspace_list()\n';
+  return [code, BlocklyPy.ORDER_NONE];
+};
+
 // Conveyor
 
 BlocklyPy['niryo_one_conveyor_models'] = function (block) {
@@ -4528,6 +5006,62 @@ const TOOLBOX = {
         {
           kind: 'BLOCK',
           type: 'niryo_one_vision_is_object_detected'
+        },
+        {
+          kind: 'BLOCK',
+          type: 'niryo_one_get_img_compressed'
+        },
+        {
+          kind: 'BLOCK',
+          type: 'niryo_one_set_brightness'
+        },
+        {
+          kind: 'BLOCK',
+          type: 'niryo_one_set_contrast'
+        },
+        {
+          kind: 'BLOCK',
+          type: 'niryo_one_set_saturation'
+        },
+        {
+          kind: 'BLOCK',
+          type: 'niryo_one_get_image_parameters'
+        },
+        {
+          kind: 'BLOCK',
+          type: 'niryo_one_get_target_pose_from_rel'
+        },
+        {
+          kind: 'BLOCK',
+          type: 'niryo_one_get_target_pose_from_cam'
+        },
+        {
+          kind: 'BLOCK',
+          type: 'niryo_one_move_to_object'
+        },
+        {
+          kind: 'BLOCK',
+          type: 'niryo_one_get_camera_intrinsics'
+        },
+        {
+          kind: 'BLOCK',
+          type: 'niryo_one_save_workspace_from_robot_poses'
+        },
+        {
+          kind: 'BLOCK',
+          type: 'niryo_one_save_workspace_from_points'
+        },
+        {
+          kind: 'BLOCK',
+          type: 'niryo_one_delete_workspace'
+        },
+        {
+          kind: 'BLOCK',
+          type: 'niryo_one_get_workspace_ratio'
+        },
+        {
+          kind: 'BLOCK',
+          type: 'niryo_one_get_workspace_list'
         },
         {
           kind: 'BLOCK',

--- a/src/niryo_one_python_generators.js
+++ b/src/niryo_one_python_generators.js
@@ -38,6 +38,7 @@ var utility_color = '#bead76';
 var vision_color = '#546e7a';
 var conveyor_color = '#00838f';
 var sound_color = '#FFC0CB';
+var frames_color = '#4B0082';
 
 // Color object for vision
 //TODO Should be in a class
@@ -892,6 +893,164 @@ Blockly.Blocks['niryo_one_clean_trajectory_memory'] = {
     this.setNextStatement(true, null);
     this.setColour(movement_color);
     this.setTooltip('Clean trajectory from Niryo’s memory');
+    this.setHelpUrl('');
+  }
+};
+
+// Dynamic frames
+
+Blockly.Blocks['niryo_one_get_saved_dynamic_frame_list'] = {
+  init: function () {
+    this.appendDummyInput().appendField('Get list of saved dynamic frames');
+    this.setOutput(true, null);
+    this.setColour(frames_color);
+    this.setTooltip('Get list of saved dynamic frames');
+    this.setHelpUrl('');
+  }
+};
+
+Blockly.Blocks['niryo_one_get_saved_dynamic_frame'] = {
+  init: function () {
+    this.appendValueInput('DYNAMIC_FRAME_NAME')
+      .setCheck('String')
+      .appendField('Get dynamic frame named');
+    this.setOutput(true, null);
+    this.setColour(frames_color);
+    this.setTooltip('Get name, description and pose of a dynamic frame');
+    this.setHelpUrl('');
+  }
+};
+
+Blockly.Blocks['niryo_one_save_dynamic_frame_from_poses'] = {
+  init: function () {
+    this.appendValueInput('DYNAMIC_FRAME_NAME')
+      .setCheck('String')
+      .appendField('Save dynamic frame under name');
+    this.appendValueInput('DYNAMIC_FRAME_DESCRIPTION')
+      .setCheck('String')
+      .appendField('and description');
+    this.appendValueInput('POSE_1')
+      .setCheck('niryo_one_pose')
+      .appendField('with origin pose');
+    this.appendValueInput('POSE_2')
+      .setCheck('niryo_one_pose')
+      .appendField('first pose');
+    this.appendValueInput('POSE_3')
+      .setCheck('niryo_one_pose')
+      .appendField('and second pose');
+    this.setPreviousStatement(true, null);
+    this.setNextStatement(true, null);
+    this.setColour(frames_color);
+    this.setTooltip(
+      'Create a dynamic frame given name, description and 3 poses (origin, x, y)'
+    );
+    this.setHelpUrl('');
+  }
+};
+
+Blockly.Blocks['niryo_one_point'] = {
+  init: function () {
+    this.appendDummyInput().appendField('Point');
+    this.appendValueInput('x').setCheck('Number').appendField('x');
+    this.appendValueInput('y').setCheck('Number').appendField('y');
+    this.appendValueInput('z').setCheck('Number').appendField('z');
+    this.setInputsInline(true);
+    this.setOutput(true, null);
+    this.setColour(frames_color);
+    this.setTooltip('Represents a point in 3D space');
+    this.setHelpUrl('');
+  }
+};
+
+Blockly.Blocks['niryo_one_save_dynamic_frame_from_points'] = {
+  init: function () {
+    this.appendValueInput('DYNAMIC_FRAME_NAME')
+      .setCheck('String')
+      .appendField('Save dynamic frame under name');
+    this.appendValueInput('DYNAMIC_FRAME_DESCRIPTION')
+      .setCheck('String')
+      .appendField('and description');
+    this.appendValueInput('POINT_1')
+      .setCheck('niryo_one_point')
+      .appendField('with origin point');
+    this.appendValueInput('POINT_2')
+      .setCheck('niryo_one_point')
+      .appendField('first point');
+    this.appendValueInput('POINT_3')
+      .setCheck('niryo_one_point')
+      .appendField('and second point');
+    this.setPreviousStatement(true, null);
+    this.setNextStatement(true, null);
+    this.setColour(frames_color);
+    this.setTooltip(
+      'Create a dynamic frame given name, description and 3 points (origin, x, y)'
+    );
+    this.setHelpUrl('');
+  }
+};
+
+Blockly.Blocks['niryo_one_edit_dynamic_frame'] = {
+  init: function () {
+    this.appendValueInput('DYNAMIC_FRAME_NAME')
+      .setCheck('String')
+      .appendField('Modify dynamic frame named');
+    this.appendValueInput('DYNAMIC_FRAME_NEW_NAME')
+      .setCheck('String')
+      .appendField('with new name');
+    this.appendValueInput('DYNAMIC_FRAME_NEW_DESCRIPTION')
+      .setCheck('String')
+      .appendField('and new description');
+    this.setPreviousStatement(true, null);
+    this.setNextStatement(true, null);
+    this.setColour(frames_color);
+    this.setTooltip('Modify a dynamic frame');
+    this.setHelpUrl('');
+  }
+};
+
+Blockly.Blocks['niryo_one_delete_dynamic_frame'] = {
+  init: function () {
+    this.appendValueInput('DYNAMIC_FRAME_NAME')
+      .setCheck('String')
+      .appendField('Modify dynamic frame named');
+    this.setPreviousStatement(true, null);
+    this.setNextStatement(true, null);
+    this.setColour(frames_color);
+    this.setTooltip('Delete a dynamic frame');
+    this.setHelpUrl('');
+  }
+};
+
+Blockly.Blocks['niryo_one_move_relative'] = {
+  init: function () {
+    this.appendValueInput('POSE')
+      .setCheck('niryo_one_pose')
+      .appendField('Move relative to pose');
+    this.appendValueInput('DYNAMIC_FRAME_NAME')
+      .setCheck('String')
+      .appendField('in frame');
+    this.setPreviousStatement(true, null);
+    this.setNextStatement(true, null);
+    this.setColour(frames_color);
+    this.setTooltip('Move robot end of a offset in a frame');
+    this.setHelpUrl('');
+  }
+};
+
+Blockly.Blocks['niryo_one_move_linear_relative'] = {
+  init: function () {
+    this.appendValueInput('POSE')
+      .setCheck('niryo_one_pose')
+      .appendField('Move linearly relative to pose');
+    this.appendValueInput('DYNAMIC_FRAME_NAME')
+      .setCheck('String')
+      .appendField('in frame');
+    this.setPreviousStatement(true, null);
+    this.setNextStatement(true, null);
+    this.setColour(frames_color);
+    this.setTooltip(
+      'Move robot end of a offset by a linear movement in a frame'
+    );
     this.setHelpUrl('');
   }
 };
@@ -2031,7 +2190,7 @@ BlocklyPy['niryo_one_pick_and_place'] = function (block) {
   );
   value_pose_2 = value_pose_2.replace('(', '').replace(')', '');
 
-  var dist_smoothing_value = Blockly.Python.valueToCode(
+  var dist_smoothing_value = BlocklyPy.valueToCode(
     block,
     'DIST_SMOOTHING',
     BlocklyPy.ORDER_ATOMIC
@@ -2162,20 +2321,20 @@ BlocklyPy['niryo_one_inverse_kinematics'] = function (block) {
 // Saved poses
 
 BlocklyPy['niryo_one_get_saved_pose'] = function (block) {
-  var value_pose_name = Blockly.Python.valueToCode(
+  var value_pose_name = BlocklyPy.valueToCode(
     block,
     'POSE_NAME',
-    Blockly.Python.ORDER_ATOMIC
+    BlocklyPy.ORDER_ATOMIC
   );
   var code = 'n.get_saved_pose(' + value_pose_name + ')\n';
   return code;
 };
 
 BlocklyPy['niryo_one_save_pose'] = function (block) {
-  var pose_name = Blockly.Python.valueToCode(
+  var pose_name = BlocklyPy.valueToCode(
     block,
     'POSE_NAME',
-    Blockly.Python.ORDER_ATOMIC
+    BlocklyPy.ORDER_ATOMIC
   );
 
   var number_pose_x = block.getFieldValue('POSE_X');
@@ -2205,10 +2364,10 @@ BlocklyPy['niryo_one_save_pose'] = function (block) {
 };
 
 BlocklyPy['niryo_one_delete_pose'] = function (block) {
-  var pose_name = Blockly.Python.valueToCode(
+  var pose_name = BlocklyPy.valueToCode(
     block,
     'POSE_NAME',
-    Blockly.Python.ORDER_ATOMIC
+    BlocklyPy.ORDER_ATOMIC
   );
   var code = 'n.delete_pose(' + pose_name + ')\n';
   return code;
@@ -2222,13 +2381,13 @@ BlocklyPy['niryo_one_get_saved_pose_list'] = function (block) {
 // Trajectories
 
 BlocklyPy['niryo_one_get_trajectory_saved'] = function (block) {
-  var value_trajectory_name = Blockly.Python.valueToCode(
+  var value_trajectory_name = BlocklyPy.valueToCode(
     block,
     'TRAJECTORY_NAME',
-    Blockly.Python.ORDER_ATOMIC
+    BlocklyPy.ORDER_ATOMIC
   );
   var code = 'n.get_trajectory_saved(' + value_trajectory_name + ')\n';
-  return [code, Blockly.Python.ORDER_NONE];
+  return [code, BlocklyPy.ORDER_NONE];
 };
 
 BlocklyPy['niryo_one_get_saved_trajectory_list'] = function (block) {
@@ -2237,26 +2396,26 @@ BlocklyPy['niryo_one_get_saved_trajectory_list'] = function (block) {
 };
 
 BlocklyPy['niryo_one_execute_registered_trajectory'] = function (block) {
-  var value_trajectory_name = Blockly.Python.valueToCode(
+  var value_trajectory_name = BlocklyPy.valueToCode(
     block,
     'TRAJECTORY_NAME',
-    Blockly.Python.ORDER_ATOMIC
+    BlocklyPy.ORDER_ATOMIC
   );
   var code = 'n.execute_registered_trajectory(' + value_trajectory_name + ')\n';
-  return [code, Blockly.Python.ORDER_NONE];
+  return [code, BlocklyPy.ORDER_NONE];
 };
 
 BlocklyPy['niryo_one_save_last_learned_trajectory'] = function (block) {
-  var trajectory_name = Blockly.Python.valueToCode(
+  var trajectory_name = BlocklyPy.valueToCode(
     block,
     'TRAJECTORY_NAME',
-    Blockly.Python.ORDER_ATOMIC
+    BlocklyPy.ORDER_ATOMIC
   );
 
-  var trajectory_description = Blockly.Python.valueToCode(
+  var trajectory_description = BlocklyPy.valueToCode(
     block,
     'TRAJECTORY_DESCRIPTION',
-    Blockly.Python.ORDER_ATOMIC
+    BlocklyPy.ORDER_ATOMIC
   );
 
   var code =
@@ -2269,10 +2428,10 @@ BlocklyPy['niryo_one_save_last_learned_trajectory'] = function (block) {
 };
 
 BlocklyPy['niryo_one_delete_trajectory'] = function (block) {
-  var trajectory_name = Blockly.Python.valueToCode(
+  var trajectory_name = BlocklyPy.valueToCode(
     block,
     'TRAJECTORY_NAME',
-    Blockly.Python.ORDER_ATOMIC
+    BlocklyPy.ORDER_ATOMIC
   );
   var code = 'n.delete_trajectory(' + trajectory_name + ')\n';
   return code;
@@ -2280,6 +2439,215 @@ BlocklyPy['niryo_one_delete_trajectory'] = function (block) {
 
 BlocklyPy['niryo_one_clean_trajectory_memory'] = function (block) {
   var code = 'n.clean_trajectory_memory()\n';
+  return code;
+};
+
+// Dynamic frames
+
+BlocklyPy['niryo_one_get_saved_dynamic_frame_list'] = function (block) {
+  var code = 'n.get_saved_dynamic_frame_list()\n';
+  return [code, BlocklyPy.ORDER_NONE];
+};
+
+BlocklyPy['niryo_one_get_saved_dynamic_frame'] = function (block) {
+  var value_dynamic_frame_name = BlocklyPy.valueToCode(
+    block,
+    'DYNAMIC_FRAME_NAME',
+    BlocklyPy.ORDER_ATOMIC
+  );
+  var code = 'n.get_saved_dynamic_frame(' + value_dynamic_frame_name + ')\n';
+  return [code, BlocklyPy.ORDER_NONE];
+};
+
+BlocklyPy['niryo_one_save_dynamic_frame_from_poses'] = function (block) {
+  var value_dynamic_frame_name = BlocklyPy.valueToCode(
+    block,
+    'DYNAMIC_FRAME_NAME',
+    BlocklyPy.ORDER_ATOMIC
+  );
+
+  var value_dynamic_frame_description = BlocklyPy.valueToCode(
+    block,
+    'DYNAMIC_FRAME_DESCRIPTION',
+    BlocklyPy.ORDER_ATOMIC
+  );
+
+  var value_pose_1 = BlocklyPy.valueToCode(
+    block,
+    'POSE_1',
+    BlocklyPy.ORDER_ATOMIC
+  );
+  value_pose_1 = value_pose_1.replace('(', '').replace(')', '');
+
+  var value_pose_2 = BlocklyPy.valueToCode(
+    block,
+    'POSE_2',
+    BlocklyPy.ORDER_ATOMIC
+  );
+  value_pose_2 = value_pose_2.replace('(', '').replace(')', '');
+
+  var value_pose_3 = BlocklyPy.valueToCode(
+    block,
+    'POSE_3',
+    BlocklyPy.ORDER_ATOMIC
+  );
+  value_pose_3 = value_pose_3.replace('(', '').replace(')', '');
+
+  var code =
+    'n.save_dynamic_frame_from_poses(' +
+    value_dynamic_frame_name +
+    ', ' +
+    value_dynamic_frame_description +
+    ', ' +
+    value_pose_1 +
+    ', ' +
+    value_pose_2 +
+    ', ' +
+    value_pose_3 +
+    ')\n';
+  return code;
+};
+
+BlocklyPy['niryo_one_point'] = function (block) {
+  var value_x = BlocklyPy.valueToCode(block, 'x', BlocklyPy.ORDER_ATOMIC)
+    .replace('(', '')
+    .replace(')', '');
+  var value_y = BlocklyPy.valueToCode(block, 'y', BlocklyPy.ORDER_ATOMIC)
+    .replace('(', '')
+    .replace(')', '');
+  var value_z = BlocklyPy.valueToCode(block, 'z', BlocklyPy.ORDER_ATOMIC)
+    .replace('(', '')
+    .replace(')', '');
+
+  var code = '[' + value_x + ', ' + value_y + ', ' + value_z + ']';
+  return [code, BlocklyPy.ORDER_NONE];
+};
+
+BlocklyPy['niryo_one_save_dynamic_frame_from_points'] = function (block) {
+  var value_dynamic_frame_name = BlocklyPy.valueToCode(
+    block,
+    'DYNAMIC_FRAME_NAME',
+    BlocklyPy.ORDER_ATOMIC
+  );
+
+  var value_dynamic_frame_description = BlocklyPy.valueToCode(
+    block,
+    'DYNAMIC_FRAME_DESCRIPTION',
+    BlocklyPy.ORDER_ATOMIC
+  );
+
+  var value_point_1 = BlocklyPy.valueToCode(
+    block,
+    'POINT_1',
+    BlocklyPy.ORDER_ATOMIC
+  );
+  value_point_1 = value_point_1.replace('(', '').replace(')', '');
+
+  var value_point_2 = BlocklyPy.valueToCode(
+    block,
+    'POINT_2',
+    BlocklyPy.ORDER_ATOMIC
+  );
+  value_point_2 = value_point_2.replace('(', '').replace(')', '');
+
+  var value_point_3 = BlocklyPy.valueToCode(
+    block,
+    'POINT_3',
+    BlocklyPy.ORDER_ATOMIC
+  );
+  value_point_3 = value_point_3.replace('(', '').replace(')', '');
+
+  var code =
+    'n.save_dynamic_frame_from_points(' +
+    value_dynamic_frame_name +
+    ', ' +
+    value_dynamic_frame_description +
+    ', ' +
+    value_point_1 +
+    ', ' +
+    value_point_2 +
+    ', ' +
+    value_point_3 +
+    ')\n';
+  return code;
+};
+
+BlocklyPy['niryo_one_edit_dynamic_frame'] = function (block) {
+  var value_dynamic_frame_name = BlocklyPy.valueToCode(
+    block,
+    'DYNAMIC_FRAME_NAME',
+    BlocklyPy.ORDER_ATOMIC
+  );
+
+  var value_dynamic_frame_new_name = BlocklyPy.valueToCode(
+    block,
+    'DYNAMIC_FRAME_NEW_NAME',
+    BlocklyPy.ORDER_ATOMIC
+  );
+
+  var value_dynamic_frame_new_description = BlocklyPy.valueToCode(
+    block,
+    'DYNAMIC_FRAME_NEW_DESCRIPTION',
+    BlocklyPy.ORDER_ATOMIC
+  );
+
+  var code =
+    'n.edit_dynamic_frame(' +
+    value_dynamic_frame_name +
+    ', ' +
+    value_dynamic_frame_new_name +
+    ', ' +
+    value_dynamic_frame_new_description +
+    ')\n';
+  return code;
+};
+
+BlocklyPy['niryo_one_delete_dynamic_frame'] = function (block) {
+  var value_dynamic_frame_name = BlocklyPy.valueToCode(
+    block,
+    'DYNAMIC_FRAME_NAME',
+    BlocklyPy.ORDER_ATOMIC
+  );
+
+  var code = 'n.delete_dynamic_frame(' + value_dynamic_frame_name + ')\n';
+  return code;
+};
+
+BlocklyPy['niryo_one_move_relative'] = function (block) {
+  var value_pose = BlocklyPy.valueToCode(block, 'POSE', BlocklyPy.ORDER_ATOMIC);
+  value_pose = value_pose.replace('(', '').replace(')', '');
+
+  var value_dynamic_frame_name = BlocklyPy.valueToCode(
+    block,
+    'DYNAMIC_FRAME_NAME',
+    BlocklyPy.ORDER_ATOMIC
+  );
+
+  var code =
+    'n.move_relative(' +
+    value_pose +
+    ', frame=' +
+    value_dynamic_frame_name +
+    ')\n';
+  return code;
+};
+
+BlocklyPy['niryo_one_move_linear_relative'] = function (block) {
+  var value_pose = BlocklyPy.valueToCode(block, 'POSE', BlocklyPy.ORDER_ATOMIC);
+  value_pose = value_pose.replace('(', '').replace(')', '');
+
+  var value_dynamic_frame_name = BlocklyPy.valueToCode(
+    block,
+    'DYNAMIC_FRAME_NAME',
+    BlocklyPy.ORDER_ATOMIC
+  );
+
+  var code =
+    'n.move_linear_relative(' +
+    value_pose +
+    ', frame=' +
+    value_dynamic_frame_name +
+    ')\n';
   return code;
 };
 
@@ -3286,6 +3654,42 @@ const TOOLBOX = {
         {
           kind: 'BLOCK',
           type: 'niryo_one_clean_trajectory_memory'
+        },
+        {
+          kind: 'BLOCK',
+          type: 'niryo_one_get_saved_dynamic_frame_list'
+        },
+        {
+          kind: 'BLOCK',
+          type: 'niryo_one_get_saved_dynamic_frame'
+        },
+        {
+          kind: 'BLOCK',
+          type: 'niryo_one_save_dynamic_frame_from_poses'
+        },
+        {
+          kind: 'BLOCK',
+          type: 'niryo_one_point'
+        },
+        {
+          kind: 'BLOCK',
+          type: 'niryo_one_save_dynamic_frame_from_points'
+        },
+        {
+          kind: 'BLOCK',
+          type: 'niryo_one_edit_dynamic_frame'
+        },
+        {
+          kind: 'BLOCK',
+          type: 'niryo_one_delete_dynamic_frame'
+        },
+        {
+          kind: 'BLOCK',
+          type: 'niryo_one_move_relative'
+        },
+        {
+          kind: 'BLOCK',
+          type: 'niryo_one_move_linear_relative'
         },
         {
           kind: 'BLOCK',

--- a/src/niryo_one_python_generators.js
+++ b/src/niryo_one_python_generators.js
@@ -896,7 +896,7 @@ Blockly.Blocks['niryo_one_clean_trajectory_memory'] = {
   }
 };
 
-// I/O
+// I/O - Hardware
 
 Blockly.Blocks['niryo_one_gpio_select'] = {
   init: function () {
@@ -979,6 +979,56 @@ Blockly.Blocks['niryo_one_digital_read'] = {
   }
 };
 
+Blockly.Blocks['niryo_one_get_hardware_status'] = {
+  init: function () {
+    this.appendDummyInput().appendField('Get hardware status');
+    this.setOutput(true, 'any');
+    this.setColour(io_color);
+    this.setTooltip(
+      'Get hardware status : Temperature, Hardware version, motors names & types …'
+    );
+    this.setHelpUrl('');
+  }
+};
+
+Blockly.Blocks['niryo_one_get_digital_io_state'] = {
+  init: function () {
+    this.appendDummyInput().appendField('Get digital IO state');
+    this.setOutput(true, 'any');
+    this.setColour(io_color);
+    this.setTooltip('Get Digital IO state : Names, modes, states.');
+    this.setHelpUrl('');
+  }
+};
+
+Blockly.Blocks['niryo_one_get_analog_io_state'] = {
+  init: function () {
+    this.appendDummyInput().appendField('Get analog IO state');
+    this.setOutput(true, 'any');
+    this.setColour(io_color);
+    this.setTooltip('Get Analog IO state : Names, modes, states.');
+    this.setHelpUrl('');
+  }
+};
+
+Blockly.Blocks['niryo_one_analog_write'] = {
+  init: function () {
+    this.appendValueInput('ANALOG_WRITE_PIN')
+      .setCheck('niryo_one_gpio_select')
+      .appendField('Set Pin');
+    this.appendDummyInput()
+      .appendField('to voltage')
+      .appendField('VOLTAGE_VALUE')
+      .setCheck('Number');
+    this.setInputsInline(true);
+    this.setPreviousStatement(true, null);
+    this.setNextStatement(true, null);
+    this.setColour(io_color);
+    this.setTooltip('Set and analog pin_id state to a value between 0 and 5V.');
+    this.setHelpUrl('');
+  }
+};
+
 Blockly.Blocks['niryo_one_gpio_state'] = {
   init: function () {
     this.appendDummyInput()
@@ -1031,6 +1081,41 @@ Blockly.Blocks['niryo_one_set_12v_switch'] = {
     this.setNextStatement(true, null);
     this.setColour(io_color);
     this.setTooltip('');
+    this.setHelpUrl('');
+  }
+};
+
+Blockly.Blocks['niryo_one_analog_write'] = {
+  init: function () {
+    this.appendValueInput('ANALOG_WRITE_PIN')
+      .setCheck('niryo_one_gpio_select')
+      .appendField('Set Pin');
+    this.appendDummyInput()
+      .appendField('to state')
+      .appendField(
+        new Blockly.FieldDropdown([
+          ['HIGH', 'PIN_HIGH'],
+          ['LOW', 'PIN_LOW']
+        ]),
+        'PIN_WRITE_SELECT'
+      );
+    this.setInputsInline(true);
+    this.setPreviousStatement(true, null);
+    this.setNextStatement(true, null);
+    this.setColour(io_color);
+    this.setTooltip('');
+    this.setHelpUrl('');
+  }
+};
+
+Blockly.Blocks['niryo_one_analog_read'] = {
+  init: function () {
+    this.appendValueInput('ANALOG_READ_PIN')
+      .setCheck('niryo_one_gpio_select')
+      .appendField('Read analog value of pin');
+    this.setOutput(true, 'any');
+    this.setColour(io_color);
+    this.setTooltip('Read the analog pin value.');
     this.setHelpUrl('');
   }
 };
@@ -2198,7 +2283,7 @@ BlocklyPy['niryo_one_clean_trajectory_memory'] = function (block) {
   return code;
 };
 
-// I/O
+// I/O - Hardware
 
 BlocklyPy['niryo_one_gpio_state'] = function (block) {
   var dropdown_gpio_state_select = block.getFieldValue('GPIO_STATE_SELECT');
@@ -2234,6 +2319,45 @@ BlocklyPy['niryo_one_digital_read'] = function (block) {
     '(0)';
   value_pin = value_pin.replace('(', '').replace(')', '');
   var code = 'n.digital_read(' + value_pin + ')';
+  return [code, BlocklyPy.ORDER_NONE];
+};
+
+BlocklyPy['niryo_one_get_hardware_status'] = function (block) {
+  var code = 'n.get_hardware_status()\n';
+  return [code, BlocklyPy.ORDER_NONE];
+};
+
+BlocklyPy['niryo_one_get_digital_io_state'] = function (block) {
+  var code = 'n.get_digital_io_state()\n';
+  return [code, BlocklyPy.ORDER_NONE];
+};
+
+BlocklyPy['niryo_one_get_analog_io_state'] = function (block) {
+  var code = 'n.get_analog_io_state()\n';
+  return [code, BlocklyPy.ORDER_NONE];
+};
+
+BlocklyPy['niryo_one_analog_write'] = function (block) {
+  var value_pin =
+    BlocklyPy.valueToCode(block, 'ANALOG_WRITE_PIN', BlocklyPy.ORDER_ATOMIC) ||
+    '(0)';
+  value_pin = value_pin.replace('(', '').replace(')', '');
+
+  var voltage_value =
+    BlocklyPy.valueToCode(block, 'VOLTAGE_VALUE', BlocklyPy.ORDER_ATOMIC) ||
+    '0';
+  voltage_value = voltage_value.replace('(', '').replace(')', '');
+
+  var code = 'n.analog_write(' + value_pin + ', ' + voltage_value + ')\n';
+  return code;
+};
+
+BlocklyPy['niryo_one_analog_read'] = function (block) {
+  var value_pin =
+    BlocklyPy.valueToCode(block, 'ANALOG_READ_PIN', BlocklyPy.ORDER_ATOMIC) ||
+    '(0)';
+  value_pin = value_pin.replace('(', '').replace(')', '');
+  var code = 'n.analog_read(' + value_pin + ')';
   return [code, BlocklyPy.ORDER_NONE];
 };
 
@@ -2581,6 +2705,7 @@ BlocklyPy['niryo_one_get_connected_conveyors_id'] = function (block) {
 };
 
 // Sound
+
 BlocklyPy['niryo_one_get_sounds'] = function (block) {
   var code = 'n.get_sounds()\n';
   return [code, BlocklyPy.ORDER_NONE];
@@ -3180,6 +3305,18 @@ const TOOLBOX = {
         },
         {
           kind: 'BLOCK',
+          type: 'niryo_one_get_hardware_status'
+        },
+        {
+          kind: 'BLOCK',
+          type: 'niryo_one_get_digital_io_state'
+        },
+        {
+          kind: 'BLOCK',
+          type: 'niryo_one_get_analog_io_state'
+        },
+        {
+          kind: 'BLOCK',
           type: 'niryo_one_gpio_state'
         },
         {
@@ -3189,6 +3326,14 @@ const TOOLBOX = {
         {
           kind: 'BLOCK',
           type: 'niryo_one_set_12v_switch'
+        },
+        {
+          kind: 'BLOCK',
+          type: 'niryo_one_analog_write'
+        },
+        {
+          kind: 'BLOCK',
+          type: 'niryo_one_analog_read'
         },
         {
           kind: 'BLOCK',

--- a/src/niryo_one_python_generators.js
+++ b/src/niryo_one_python_generators.js
@@ -37,6 +37,7 @@ var tool_color = '#bf964b';
 var utility_color = '#bead76';
 var vision_color = '#546e7a';
 var conveyor_color = '#00838f';
+var sound_color = '#FFC0CB';
 
 // Color object for vision
 //TODO Should be in a class
@@ -1430,12 +1431,126 @@ Blockly.Blocks['niryo_one_get_connected_conveyors_id'] = {
     this.appendDummyInput().appendField('Get list of connected conveyors');
     this.setOutput(true, null);
     this.setColour(conveyor_color);
-    this.setPreviousStatement(true, null);
-    this.setNextStatement(true, null);
     this.setHelpUrl('');
     this.setTooltip('Conveyors directions available with Niryo One.');
   }
 };
+
+// Sound
+
+Blockly.Blocks['niryo_one_get_sounds'] = {
+  init: function () {
+    this.appendDummyInput().appendField('Get sound name list');
+    this.setOutput(true, null);
+    this.setColour(sound_color);
+    this.setHelpUrl('');
+    this.setTooltip('Get sound name list.');
+  }
+};
+
+Blockly.Blocks['niryo_one_set_volume'] = {
+  init: function () {
+    this.appendValueInput('SET_VOLUME')
+      .setCheck('Number')
+      .appendField('Set volume procentage of robot to');
+    this.appendDummyInput().appendField('%');
+    this.setInputsInline(true);
+    this.setPreviousStatement(true, null);
+    this.setNextStatement(true, null);
+    this.setColour(sound_color);
+    this.setTooltip(
+      'Set the volume percentage of the robot. Volume percentage of the sound (0: no sound, 100: max sound)'
+    );
+    this.setHelpUrl('');
+  }
+};
+
+Blockly.Blocks['niryo_one_stop_sound'] = {
+  init: function () {
+    this.appendDummyInput().appendField('Stop sound');
+    this.setPreviousStatement(true, null);
+    this.setNextStatement(true, null);
+    this.setColour(sound_color);
+    this.setHelpUrl('');
+    this.setTooltip('Stop a sound being played.');
+  }
+};
+
+Blockly.Blocks['niryo_one_get_sound_duration'] = {
+  init: function () {
+    this.appendValueInput('SOUND_NAME')
+      .setCheck('String')
+      .appendField('Get duration of sound named');
+    this.setOutput(true, null);
+    this.setColour(sound_color);
+    this.setHelpUrl('');
+    this.setTooltip(
+      'Returns the duration in seconds of a sound stored in the robot database raise SoundRosWrapperException if the sound doesn’t exists'
+    );
+  }
+};
+
+Blockly.Blocks['niryo_one_play_sound'] = {
+  init: function () {
+    this.appendValueInput('SOUND_NAME')
+      .setCheck('String')
+      .appendField('Play sound named');
+
+    // this.appendValueInput('WAIT_END')
+    //   .setcheck('Boolean')
+    //   .appendField('wait until the end');
+
+    this.appendDummyInput().appendField('wait until the end');
+    this.appendDummyInput().appendField(
+      new Blockly.FieldDropdown([
+        ['True', '1'],
+        ['False', '0']
+      ]),
+      'WAIT_END'
+    );
+
+    this.appendValueInput('START_TIME')
+      .setCheck('Number')
+      .appendField('starting from this second');
+
+    this.appendValueInput('END_TIME')
+      .setCheck('Number')
+      .appendField('ending at this second');
+
+    this.setPreviousStatement(true, null);
+    this.setNextStatement(true, null);
+    this.setColour(sound_color);
+    this.setHelpUrl('');
+    this.setTooltip(
+      'Play a sound from the robot, given its name, whether to for the end of the sound before exiting the function (True or False), the start time of the sound from the value in seconds and end time of the sound at this value in seconds.'
+    );
+  }
+};
+
+Blockly.Blocks['niryo_one_say'] = {
+  init: function () {
+    this.appendValueInput('SAY_TEXT').setCheck('String').appendField('Say');
+    this.appendDummyInput().appendField('in');
+    this.appendDummyInput().appendField(
+      new Blockly.FieldDropdown([
+        ['English', '0'],
+        ['French', '1'],
+        ['Spanish', '2'],
+        ['Mandarin', '3'],
+        ['Portuguese', '4']
+      ]),
+      'LANGUAGE_SELECT'
+    );
+    this.setPreviousStatement(true, null);
+    this.setNextStatement(true, null);
+    this.setColour(sound_color);
+    this.setHelpUrl('');
+    this.setTooltip(
+      'Use gtts (Google Text To Speech) to interprete a string as sound.'
+    );
+  }
+};
+
 /*
  * Generators
  */
@@ -2338,7 +2453,76 @@ BlocklyPy['niryo_one_get_connected_conveyors_id'] = function (block) {
   return code;
 };
 
-// Creating a toolbox containing all the main (default) blocks.
+// Sound
+BlocklyPy['niryo_one_get_sounds'] = function (block) {
+  var code = 'n.get_sounds()\n';
+  return [code, BlocklyPy.ORDER_NONE];
+};
+
+BlocklyPy['niryo_one_set_volume'] = function (block) {
+  var value_set_volume =
+    BlocklyPy.valueToCode(block, 'SET_VOLUME', BlocklyPy.ORDER_ATOMIC) || '0';
+  value_set_volume = value_set_volume.replace('(', '').replace(')', '');
+  var code = 'n.set_volume(' + value_set_volume + ')\n';
+  return code;
+};
+
+BlocklyPy['niryo_one_stop_sound'] = function (block) {
+  var code = 'n.stop_sound()\n';
+  return [code, BlocklyPy.ORDER_NONE];
+};
+
+BlocklyPy['niryo_one_get_sound_duration'] = function (block) {
+  var value_sound_name =
+    BlocklyPy.valueToCode(block, 'SOUND_NAME', BlocklyPy.ORDER_ATOMIC) || '0';
+  value_sound_name = value_sound_name.replace('(', '').replace(')', '');
+  var code = 'n.get_sound_duration(' + value_sound_name + ')\n';
+  return [code, BlocklyPy.ORDER_NONE];
+};
+
+BlocklyPy['niryo_one_play_sound'] = function (block) {
+  var value_sound_name =
+    BlocklyPy.valueToCode(block, 'SOUND_NAME', BlocklyPy.ORDER_ATOMIC) || '0';
+  value_sound_name = value_sound_name.replace('(', '').replace(')', '');
+
+  var dropdown_wait_end = block.getFieldValue('WAIT_END');
+
+  var value_start_time =
+    BlocklyPy.valueToCode(block, 'START_TIME', BlocklyPy.ORDER_ATOMIC) || '0';
+  value_start_time = value_start_time.replace('(', '').replace(')', '');
+
+  var value_end_time =
+    BlocklyPy.valueToCode(block, 'END_TIME', BlocklyPy.ORDER_ATOMIC) || '0';
+  value_end_time = value_end_time.replace('(', '').replace(')', '');
+
+  var code =
+    'n.play_sound(' +
+    value_sound_name +
+    ', ' +
+    dropdown_wait_end +
+    ', ' +
+    value_start_time +
+    ', ' +
+    value_end_time +
+    ')\n';
+
+  return code;
+};
+
+BlocklyPy['niryo_one_say'] = function (block) {
+  var value_say_text =
+    BlocklyPy.valueToCode(block, 'SAY_TEXT', BlocklyPy.ORDER_ATOMIC) || '0';
+  value_say_text = value_say_text.replace('(', '').replace(')', '');
+
+  var dropdown_language_select = block.getFieldValue('LANGUAGE_SELECT');
+
+  var code =
+    'n.say(' + value_say_text + ', ' + dropdown_language_select + ')\n';
+  return code;
+};
+
+// Creating a toolbox containing all the main (default) blocks
+// and adding the niryo category.
 const TOOLBOX = {
   kind: 'categoryToolbox',
   contents: [
@@ -2970,6 +3154,30 @@ const TOOLBOX = {
         {
           kind: 'BLOCK',
           type: 'niryo_one_get_connected_conveyors_id'
+        },
+        {
+          kind: 'BLOCK',
+          type: 'niryo_one_get_sounds'
+        },
+        {
+          kind: 'BLOCK',
+          type: 'niryo_one_set_volume'
+        },
+        {
+          kind: 'BLOCK',
+          type: 'niryo_one_stop_sound'
+        },
+        {
+          kind: 'BLOCK',
+          type: 'niryo_one_get_sound_duration'
+        },
+        {
+          kind: 'BLOCK',
+          type: 'niryo_one_play_sound'
+        },
+        {
+          kind: 'BLOCK',
+          type: 'niryo_one_say'
         }
       ]
     }

--- a/src/niryo_one_python_generators.js
+++ b/src/niryo_one_python_generators.js
@@ -39,6 +39,8 @@ var vision_color = '#546e7a';
 var conveyor_color = '#00838f';
 var sound_color = '#FFC0CB';
 var frames_color = '#4B0082';
+var led_color = '65c368';
+var trajectory_color = '#9370DB';
 
 // Color object for vision
 //TODO Should be in a class
@@ -828,7 +830,7 @@ Blockly.Blocks['niryo_one_get_trajectory_saved'] = {
       .setCheck('String')
       .appendField('Get trajectory named');
     this.setOutput(true, null);
-    this.setColour(movement_color);
+    this.setColour(trajectory_color);
     this.setTooltip('Get trajectory saved in Niryo’s memory');
     this.setHelpUrl('');
   }
@@ -838,7 +840,7 @@ Blockly.Blocks['niryo_one_get_saved_trajectory_list'] = {
   init: function () {
     this.appendDummyInput().appendField('Get list of saved trajectories');
     this.setOutput(true, null);
-    this.setColour(movement_color);
+    this.setColour(trajectory_color);
     this.setTooltip('');
     this.setHelpUrl('');
   }
@@ -850,7 +852,7 @@ Blockly.Blocks['niryo_one_execute_registered_trajectory'] = {
       .setCheck('String')
       .appendField('Execute trajectory named');
     this.setOutput(true, null);
-    this.setColour(movement_color);
+    this.setColour(trajectory_color);
     this.setTooltip('Execute trajectory from Niryo’s memory');
     this.setHelpUrl('');
   }
@@ -864,7 +866,7 @@ Blockly.Blocks['niryo_one_save_last_learned_trajectory'] = {
     this.appendValueInput('TRAJECTORY_DESCRIPTION')
       .setCheck('String')
       .appendField('and description');
-    this.setColour(movement_color);
+    this.setColour(trajectory_color);
     this.setInputsInline(true);
     this.setPreviousStatement(true, null);
     this.setNextStatement(true, null);
@@ -880,7 +882,7 @@ Blockly.Blocks['niryo_one_delete_trajectory'] = {
       .appendField('Delete trajectory named');
     this.setPreviousStatement(true, null);
     this.setNextStatement(true, null);
-    this.setColour(movement_color);
+    this.setColour(trajectory_color);
     this.setTooltip('Delete trajectory from Niryo’s memory');
     this.setHelpUrl('');
   }
@@ -891,7 +893,7 @@ Blockly.Blocks['niryo_one_clean_trajectory_memory'] = {
     this.appendDummyInput().appendField('Clean trajectory memory');
     this.setPreviousStatement(true, null);
     this.setNextStatement(true, null);
-    this.setColour(movement_color);
+    this.setColour(trajectory_color);
     this.setTooltip('Clean trajectory from Niryo’s memory');
     this.setHelpUrl('');
   }
@@ -1874,6 +1876,281 @@ Blockly.Blocks['niryo_one_say'] = {
     this.setHelpUrl('');
     this.setTooltip(
       'Use gtts (Google Text To Speech) to interprete a string as sound.'
+    );
+  }
+};
+
+// Led Ring
+
+Blockly.Blocks['niryo_one_color'] = {
+  init: function () {
+    // this.appendDummyInput().appendField('Color');
+    this.appendValueInput('RED').setCheck('Number').appendField('R');
+    this.appendValueInput('GREEN').setCheck('Number').appendField('G');
+    this.appendValueInput('BLUE').setCheck('Number').appendField('B');
+    this.setOutput(true, null);
+    this.setColour(led_color);
+    this.setHelpUrl('');
+    this.setTooltip(
+      'Define color in RGB. Each value has to be between 0 and 255.'
+    );
+  }
+};
+
+Blockly.Blocks['niryo_one_set_led_color'] = {
+  init: function () {
+    this.appendValueInput('LED_RING_ID')
+      .setCheck('Number')
+      .appendField('Set led ring with id');
+    this.appendValueInput('COLOR')
+      .setCheck('niryo_one_color')
+      .appendField('to color');
+    this.setPreviousStatement(true, null);
+    this.setNextStatement(true, null);
+    this.setColour(led_color);
+    this.setHelpUrl('');
+    this.setTooltip('Set led ring color. The led id is between 0 and 29.');
+  }
+};
+
+Blockly.Blocks['niryo_one_led_ring_solid'] = {
+  init: function () {
+    this.appendValueInput('COLOR')
+      .setCheck('niryo_one_color')
+      .appendField('Set ring to color');
+    this.setPreviousStatement(true, null);
+    this.setNextStatement(true, null);
+    this.setColour(led_color);
+    this.setHelpUrl('');
+    this.setTooltip('Set the whole Led Ring to a fixed color.');
+  }
+};
+
+Blockly.Blocks['niryo_one_led_ring_turn_off'] = {
+  init: function () {
+    this.appendDummyInput().appendField('Turn off led ring');
+    this.setPreviousStatement(true, null);
+    this.setNextStatement(true, null);
+    this.setColour(led_color);
+    this.setHelpUrl('');
+    this.setTooltip('Turn off all LEDs.');
+  }
+};
+
+Blockly.Blocks['niryo_one_led_ring_flashing'] = {
+  init: function () {
+    this.appendValueInput('COLOR')
+      .setCheck('niryo_one_color')
+      .appendField('Flash ring to color');
+    this.appendValueInput('PERIOD')
+      .setCheck('Number')
+      .appendField('for duration');
+    this.appendValueInput('ITERATIONS')
+      .setCheck('Number')
+      .appendField('at frequency');
+    this.setPreviousStatement(true, null);
+    this.setNextStatement(true, null);
+    this.setColour(led_color);
+    this.setHelpUrl('');
+    this.setTooltip(
+      'Flashes a color according to a frequency. The frequency is equal to 1 / period. Duration for a pattern is in seconds, if 0 default time will be used. Frequency considered as number of consecutive flashses, if 0 the led ring flashes endlessly.'
+    );
+  }
+};
+
+Blockly.Blocks['niryo_one_led_ring_alternate'] = {
+  init: function () {
+    this.appendValueInput('COLOR_1')
+      .setCheck('niryo_one_color')
+      .appendField('Alternate ring to colors');
+    this.appendValueInput('COLOR_2').setCheck('niryo_one_color');
+    this.appendValueInput('COLOR_3').setCheck('niryo_one_color');
+    this.appendValueInput('PERIOD')
+      .setCheck('Number')
+      .appendField('for duration');
+    this.appendValueInput('ITERATIONS')
+      .setCheck('Number')
+      .appendField('at frequency');
+    this.setPreviousStatement(true, null);
+    this.setNextStatement(true, null);
+    this.setColour(led_color);
+    this.setHelpUrl('');
+    this.setTooltip(
+      'Several colors are alternated one after the other. The frequency is equal to 1 / period. Duration for a pattern is in seconds, if 0 default time will be used. Frequency considered as number of consecutive alternates, if 0 the led ring alternates endlessly.'
+    );
+  }
+};
+
+Blockly.Blocks['niryo_one_led_ring_chase'] = {
+  init: function () {
+    this.appendValueInput('COLOR')
+      .setCheck('niryo_one_color')
+      .appendField('Chaser ring animation to color');
+    this.appendValueInput('PERIOD')
+      .setCheck('Number')
+      .appendField('for duration');
+    this.appendValueInput('ITERATIONS')
+      .setCheck('Number')
+      .appendField('at frequency');
+    this.setPreviousStatement(true, null);
+    this.setNextStatement(true, null);
+    this.setColour(led_color);
+    this.setHelpUrl('');
+    this.setTooltip(
+      'Movie theater light style chaser animation. The frequency is equal to 1 / period. Duration for a pattern is in seconds, if 0 default time will be used. Frequency considered as number of consecutive flashses, if 0 the led ring flashes endlessly.'
+    );
+  }
+};
+
+Blockly.Blocks['niryo_one_led_ring_wipe'] = {
+  init: function () {
+    this.appendValueInput('COLOR')
+      .setCheck('niryo_one_color')
+      .appendField('Wipe across led ring the color');
+    this.appendValueInput('PERIOD')
+      .setCheck('Number')
+      .appendField('for duration');
+    this.setPreviousStatement(true, null);
+    this.setNextStatement(true, null);
+    this.setColour(led_color);
+    this.setHelpUrl('');
+    this.setTooltip('Wipe a color across the Led Ring, light a Led at a time.');
+  }
+};
+
+Blockly.Blocks['niryo_one_led_ring_rainbow'] = {
+  init: function () {
+    this.appendDummyInput().appendField('Fading rainbow animation');
+    this.appendValueInput('PERIOD')
+      .setCheck('Number')
+      .appendField('for duration');
+    this.appendValueInput('ITERATIONS')
+      .setCheck('Number')
+      .appendField('at frequency');
+    this.setPreviousStatement(true, null);
+    this.setNextStatement(true, null);
+    this.setColour(led_color);
+    this.setHelpUrl('');
+    this.setTooltip('Draw rainbow that fades across all LEDs at once.');
+  }
+};
+
+Blockly.Blocks['niryo_one_led_ring_rainbow_cycle'] = {
+  init: function () {
+    this.appendDummyInput().appendField('Draw rainbow');
+    this.appendValueInput('PERIOD')
+      .setCheck('Number')
+      .appendField('for duration');
+    this.appendValueInput('ITERATIONS')
+      .setCheck('Number')
+      .appendField('at frequency');
+    this.setPreviousStatement(true, null);
+    this.setNextStatement(true, null);
+    this.setColour(led_color);
+    this.setHelpUrl('');
+    this.setTooltip(
+      'Draw rainbow that uniformly distributes itself across all LEDs.'
+    );
+  }
+};
+
+Blockly.Blocks['niryo_one_led_ring_rainbow_chase'] = {
+  init: function () {
+    this.appendDummyInput().appendField('Rainbow chase animation');
+    this.appendValueInput('PERIOD')
+      .setCheck('Number')
+      .appendField('for duration');
+    this.appendValueInput('ITERATIONS')
+      .setCheck('Number')
+      .appendField('at frequency');
+    this.setPreviousStatement(true, null);
+    this.setNextStatement(true, null);
+    this.setColour(led_color);
+    this.setHelpUrl('');
+    this.setTooltip('Rainbow chase animation, like the led_ring_chase method.');
+  }
+};
+
+Blockly.Blocks['niryo_one_led_ring_go_up'] = {
+  init: function () {
+    this.appendValueInput('COLOR')
+      .setCheck('niryo_one_color')
+      .appendField('Led ring go up in color');
+    this.appendValueInput('PERIOD')
+      .setCheck('Number')
+      .appendField('for duration');
+    this.appendValueInput('ITERATIONS')
+      .setCheck('Number')
+      .appendField('at frequency');
+    this.setPreviousStatement(true, null);
+    this.setNextStatement(true, null);
+    this.setColour(led_color);
+    this.setHelpUrl('');
+    this.setTooltip(
+      'LEDs turn on like a loading circle, and are then all turned off at once.'
+    );
+  }
+};
+
+Blockly.Blocks['niryo_one_led_ring_go_up_down'] = {
+  init: function () {
+    this.appendValueInput('COLOR')
+      .setCheck('niryo_one_color')
+      .appendField('Load circle in color');
+    this.appendValueInput('PERIOD')
+      .setCheck('Number')
+      .appendField('for duration');
+    this.appendValueInput('ITERATIONS')
+      .setCheck('Number')
+      .appendField('at frequency');
+    this.setPreviousStatement(true, null);
+    this.setNextStatement(true, null);
+    this.setColour(led_color);
+    this.setHelpUrl('');
+    this.setTooltip(
+      'LEDs turn on like a loading circle, and are turned off the same way.'
+    );
+  }
+};
+
+Blockly.Blocks['niryo_one_led_ring_breath'] = {
+  init: function () {
+    this.appendValueInput('COLOR')
+      .setCheck('niryo_one_color')
+      .appendField('LED ring lights up like breathing in color');
+    this.appendValueInput('PERIOD')
+      .setCheck('Number')
+      .appendField('for duration');
+    this.appendValueInput('ITERATIONS')
+      .setCheck('Number')
+      .appendField('at frequency');
+    this.setPreviousStatement(true, null);
+    this.setNextStatement(true, null);
+    this.setColour(led_color);
+    this.setHelpUrl('');
+    this.setTooltip(
+      'Variation of the light intensity of the LED ring, similar to human breathing.'
+    );
+  }
+};
+
+Blockly.Blocks['niryo_one_led_ring_snake'] = {
+  init: function () {
+    this.appendValueInput('COLOR')
+      .setCheck('niryo_one_color')
+      .appendField('Snake lights up in color');
+    this.appendValueInput('PERIOD')
+      .setCheck('Number')
+      .appendField('for duration');
+    this.appendValueInput('ITERATIONS')
+      .setCheck('Number')
+      .appendField('at frequency');
+    this.setPreviousStatement(true, null);
+    this.setNextStatement(true, null);
+    this.setColour(led_color);
+    this.setHelpUrl('');
+    this.setTooltip(
+      'A small coloured snake (certainly a python :D ) runs around the LED ring.'
     );
   }
 };
@@ -3141,6 +3418,435 @@ BlocklyPy['niryo_one_say'] = function (block) {
   return code;
 };
 
+//Led Ring
+
+BlocklyPy['niryo_one_color'] = function (block) {
+  var value_r = BlocklyPy.valueToCode(block, 'RED', BlocklyPy.ORDER_ATOMIC)
+    .replace('(', '')
+    .replace(')', '');
+  var value_g = BlocklyPy.valueToCode(block, 'GREEN', BlocklyPy.ORDER_ATOMIC)
+    .replace('(', '')
+    .replace(')', '');
+  var value_b = BlocklyPy.valueToCode(block, 'BLUE', BlocklyPy.ORDER_ATOMIC)
+    .replace('(', '')
+    .replace(')', '');
+
+  var code = '[' + value_r + ', ' + value_g + ', ' + value_b + ']';
+  return [code, BlocklyPy.ORDER_NONE];
+};
+
+BlocklyPy['niryo_one_set_led_color'] = function (block) {
+  var value_led_ring_id = BlocklyPy.valueToCode(
+    block,
+    'LED_RING_ID',
+    BlocklyPy.ORDER_ATOMIC
+  )
+    .replace('(', '')
+    .replace(')', '');
+
+  var value_color = BlocklyPy.valueToCode(
+    block,
+    'COLOR',
+    BlocklyPy.ORDER_ATOMIC
+  )
+    .replace('(', '')
+    .replace(')', '');
+
+  var code =
+    'n.set_led_color(' + value_led_ring_id + ', ' + value_color + ')\n';
+  return code;
+};
+
+BlocklyPy['niryo_one_led_ring_solid'] = function (block) {
+  var value_color = BlocklyPy.valueToCode(
+    block,
+    'COLOR',
+    BlocklyPy.ORDER_ATOMIC
+  )
+    .replace('(', '')
+    .replace(')', '');
+
+  var code = 'n.led_ring_solid(' + value_color + ')\n';
+  return code;
+};
+
+BlocklyPy['niryo_one_led_ring_turn_off'] = function (block) {
+  var code = 'n.led_ring_turn_off()\n';
+  return code;
+};
+
+BlocklyPy['niryo_one_led_ring_flashing'] = function (block) {
+  var value_color = BlocklyPy.valueToCode(
+    block,
+    'COLOR',
+    BlocklyPy.ORDER_ATOMIC
+  )
+    .replace('(', '')
+    .replace(')', '');
+
+  var value_period = BlocklyPy.valueToCode(
+    block,
+    'PERIOD',
+    BlocklyPy.ORDER_ATOMIC
+  )
+    .replace('(', '')
+    .replace(')', '');
+
+  var value_iterations = BlocklyPy.valueToCode(
+    block,
+    'ITERATIONS',
+    BlocklyPy.ORDER_ATOMIC
+  )
+    .replace('(', '')
+    .replace(')', '');
+
+  var code =
+    'n.led_ring_flashing(' +
+    value_color +
+    ', ' +
+    value_period +
+    ', ' +
+    value_iterations +
+    ', True)\n';
+  return code;
+};
+
+BlocklyPy['niryo_one_led_ring_alternate'] = function (block) {
+  var value_color_1 = BlocklyPy.valueToCode(
+    block,
+    'COLOR_1',
+    BlocklyPy.ORDER_ATOMIC
+  )
+    .replace('(', '')
+    .replace(')', '');
+
+  var value_color_2 = BlocklyPy.valueToCode(
+    block,
+    'COLOR_2',
+    BlocklyPy.ORDER_ATOMIC
+  )
+    .replace('(', '')
+    .replace(')', '');
+
+  var value_color_3 = BlocklyPy.valueToCode(
+    block,
+    'COLOR_3',
+    BlocklyPy.ORDER_ATOMIC
+  )
+    .replace('(', '')
+    .replace(')', '');
+
+  var value_period = BlocklyPy.valueToCode(
+    block,
+    'PERIOD',
+    BlocklyPy.ORDER_ATOMIC
+  )
+    .replace('(', '')
+    .replace(')', '');
+
+  var value_iterations = BlocklyPy.valueToCode(
+    block,
+    'ITERATIONS',
+    BlocklyPy.ORDER_ATOMIC
+  )
+    .replace('(', '')
+    .replace(')', '');
+
+  var code =
+    'n.led_ring_alternate( [' +
+    value_color_1 +
+    ', ' +
+    value_color_2 +
+    ', ' +
+    value_color_3 +
+    '], ' +
+    value_period +
+    ', ' +
+    value_iterations +
+    ', True)\n';
+  return code;
+};
+
+BlocklyPy['niryo_one_led_ring_chase'] = function (block) {
+  var value_color = BlocklyPy.valueToCode(
+    block,
+    'COLOR',
+    BlocklyPy.ORDER_ATOMIC
+  )
+    .replace('(', '')
+    .replace(')', '');
+
+  var value_period = BlocklyPy.valueToCode(
+    block,
+    'PERIOD',
+    BlocklyPy.ORDER_ATOMIC
+  )
+    .replace('(', '')
+    .replace(')', '');
+
+  var value_iterations = BlocklyPy.valueToCode(
+    block,
+    'ITERATIONS',
+    BlocklyPy.ORDER_ATOMIC
+  )
+    .replace('(', '')
+    .replace(')', '');
+
+  var code =
+    'n.led_ring_chase(' +
+    value_color +
+    ', ' +
+    value_period +
+    ', ' +
+    value_iterations +
+    ', True)\n';
+  return code;
+};
+
+BlocklyPy['niryo_one_led_ring_wipe'] = function (block) {
+  var value_color = BlocklyPy.valueToCode(
+    block,
+    'COLOR',
+    BlocklyPy.ORDER_ATOMIC
+  )
+    .replace('(', '')
+    .replace(')', '');
+
+  var value_period = BlocklyPy.valueToCode(
+    block,
+    'PERIOD',
+    BlocklyPy.ORDER_ATOMIC
+  )
+    .replace('(', '')
+    .replace(')', '');
+
+  var code =
+    'n.led_ring_wipe(' + value_color + ', ' + value_period + ', True)\n';
+  return code;
+};
+
+BlocklyPy['niryo_one_led_ring_rainbow'] = function (block) {
+  var value_period = BlocklyPy.valueToCode(
+    block,
+    'PERIOD',
+    BlocklyPy.ORDER_ATOMIC
+  )
+    .replace('(', '')
+    .replace(')', '');
+
+  var value_iterations = BlocklyPy.valueToCode(
+    block,
+    'ITERATIONS',
+    BlocklyPy.ORDER_ATOMIC
+  )
+    .replace('(', '')
+    .replace(')', '');
+
+  var code =
+    'n.led_ring_rainbow(' +
+    value_period +
+    ', ' +
+    value_iterations +
+    ', True)\n';
+  return code;
+};
+
+BlocklyPy['niryo_one_led_ring_rainbow_cycle'] = function (block) {
+  var value_period = BlocklyPy.valueToCode(
+    block,
+    'PERIOD',
+    BlocklyPy.ORDER_ATOMIC
+  )
+    .replace('(', '')
+    .replace(')', '');
+
+  var value_iterations = BlocklyPy.valueToCode(
+    block,
+    'ITERATIONS',
+    BlocklyPy.ORDER_ATOMIC
+  )
+    .replace('(', '')
+    .replace(')', '');
+
+  var code =
+    'n.led_ring_rainbow_cycle(' +
+    value_period +
+    ', ' +
+    value_iterations +
+    ', True)\n';
+  return code;
+};
+
+BlocklyPy['niryo_one_led_ring_rainbow_chase'] = function (block) {
+  var value_period = BlocklyPy.valueToCode(
+    block,
+    'PERIOD',
+    BlocklyPy.ORDER_ATOMIC
+  )
+    .replace('(', '')
+    .replace(')', '');
+
+  var value_iterations = BlocklyPy.valueToCode(
+    block,
+    'ITERATIONS',
+    BlocklyPy.ORDER_ATOMIC
+  )
+    .replace('(', '')
+    .replace(')', '');
+
+  var code =
+    'n.led_ring_rainbow_chase(' +
+    value_period +
+    ', ' +
+    value_iterations +
+    ', True)\n';
+  return code;
+};
+
+BlocklyPy['niryo_one_led_ring_go_up'] = function (block) {
+  var value_color = BlocklyPy.valueToCode(
+    block,
+    'COLOR',
+    BlocklyPy.ORDER_ATOMIC
+  )
+    .replace('(', '')
+    .replace(')', '');
+
+  var value_period = BlocklyPy.valueToCode(
+    block,
+    'PERIOD',
+    BlocklyPy.ORDER_ATOMIC
+  )
+    .replace('(', '')
+    .replace(')', '');
+
+  var value_iterations = BlocklyPy.valueToCode(
+    block,
+    'ITERATIONS',
+    BlocklyPy.ORDER_ATOMIC
+  )
+    .replace('(', '')
+    .replace(')', '');
+
+  var code =
+    'n.led_ring_go_up(' +
+    value_color +
+    ', ' +
+    value_period +
+    ', ' +
+    value_iterations +
+    ', True)\n';
+  return code;
+};
+
+BlocklyPy['niryo_one_led_ring_go_up_down'] = function (block) {
+  var value_color = BlocklyPy.valueToCode(
+    block,
+    'COLOR',
+    BlocklyPy.ORDER_ATOMIC
+  )
+    .replace('(', '')
+    .replace(')', '');
+
+  var value_period = BlocklyPy.valueToCode(
+    block,
+    'PERIOD',
+    BlocklyPy.ORDER_ATOMIC
+  )
+    .replace('(', '')
+    .replace(')', '');
+
+  var value_iterations = BlocklyPy.valueToCode(
+    block,
+    'ITERATIONS',
+    BlocklyPy.ORDER_ATOMIC
+  )
+    .replace('(', '')
+    .replace(')', '');
+
+  var code =
+    'n.led_ring_go_up_down(' +
+    value_color +
+    ', ' +
+    value_period +
+    ', ' +
+    value_iterations +
+    ', True)\n';
+  return code;
+};
+
+BlocklyPy['niryo_one_led_ring_breath'] = function (block) {
+  var value_color = BlocklyPy.valueToCode(
+    block,
+    'COLOR',
+    BlocklyPy.ORDER_ATOMIC
+  )
+    .replace('(', '')
+    .replace(')', '');
+
+  var value_period = BlocklyPy.valueToCode(
+    block,
+    'PERIOD',
+    BlocklyPy.ORDER_ATOMIC
+  )
+    .replace('(', '')
+    .replace(')', '');
+
+  var value_iterations = BlocklyPy.valueToCode(
+    block,
+    'ITERATIONS',
+    BlocklyPy.ORDER_ATOMIC
+  )
+    .replace('(', '')
+    .replace(')', '');
+
+  var code =
+    'n.led_ring_breath(' +
+    value_color +
+    ', ' +
+    value_period +
+    ', ' +
+    value_iterations +
+    ', True)\n';
+  return code;
+};
+
+BlocklyPy['niryo_one_led_ring_snake'] = function (block) {
+  var value_color = BlocklyPy.valueToCode(
+    block,
+    'COLOR',
+    BlocklyPy.ORDER_ATOMIC
+  )
+    .replace('(', '')
+    .replace(')', '');
+
+  var value_period = BlocklyPy.valueToCode(
+    block,
+    'PERIOD',
+    BlocklyPy.ORDER_ATOMIC
+  )
+    .replace('(', '')
+    .replace(')', '');
+
+  var value_iterations = BlocklyPy.valueToCode(
+    block,
+    'ITERATIONS',
+    BlocklyPy.ORDER_ATOMIC
+  )
+    .replace('(', '')
+    .replace(')', '');
+
+  var code =
+    'n.led_ring_snake(' +
+    value_color +
+    ', ' +
+    value_period +
+    ', ' +
+    value_iterations +
+    ', True)\n';
+  return code;
+};
+
 // Creating a toolbox containing all the main (default) blocks
 // and adding the niryo category.
 const TOOLBOX = {
@@ -3874,6 +4580,66 @@ const TOOLBOX = {
         {
           kind: 'BLOCK',
           type: 'niryo_one_say'
+        },
+        {
+          kind: 'BLOCK',
+          type: 'niryo_one_color'
+        },
+        {
+          kind: 'BLOCK',
+          type: 'niryo_one_set_led_color'
+        },
+        {
+          kind: 'BLOCK',
+          type: 'niryo_one_led_ring_solid'
+        },
+        {
+          kind: 'BLOCK',
+          type: 'niryo_one_led_ring_turn_off'
+        },
+        {
+          kind: 'BLOCK',
+          type: 'niryo_one_led_ring_flashing'
+        },
+        {
+          kind: 'BLOCK',
+          type: 'niryo_one_led_ring_alternate'
+        },
+        {
+          kind: 'BLOCK',
+          type: 'niryo_one_led_ring_chase'
+        },
+        {
+          kind: 'BLOCK',
+          type: 'niryo_one_led_ring_wipe'
+        },
+        {
+          kind: 'BLOCK',
+          type: 'niryo_one_led_ring_rainbow'
+        },
+        {
+          kind: 'BLOCK',
+          type: 'niryo_one_led_ring_rainbow_cycle'
+        },
+        {
+          kind: 'BLOCK',
+          type: 'niryo_one_led_ring_rainbow_chase'
+        },
+        {
+          kind: 'BLOCK',
+          type: 'niryo_one_led_ring_go_up'
+        },
+        {
+          kind: 'BLOCK',
+          type: 'niryo_one_led_ring_go_up_down'
+        },
+        {
+          kind: 'BLOCK',
+          type: 'niryo_one_led_ring_breath'
+        },
+        {
+          kind: 'BLOCK',
+          type: 'niryo_one_led_ring_snake'
         }
       ]
     }

--- a/src/niryo_one_python_generators.js
+++ b/src/niryo_one_python_generators.js
@@ -118,7 +118,9 @@ Blockly.Blocks['niryo_one_move_joints'] = {
     this.setPreviousStatement(true, null);
     this.setNextStatement(true, null);
     this.setColour(movement_color);
-    this.setTooltip('Give all 6 joints to move the robot. Joints are expressed in radians.');
+    this.setTooltip(
+      'Give all 6 joints to move the robot. Joints are expressed in radians.'
+    );
     this.setHelpUrl('');
   }
 };
@@ -161,7 +163,9 @@ Blockly.Blocks['niryo_one_move_pose'] = {
     this.setPreviousStatement(true, null);
     this.setNextStatement(true, null);
     this.setColour(movement_color);
-    this.setTooltip('Move robot end effector pose to a (x, y, z, roll, pitch, yaw, frame_name) pose. x, y & z are expressed in meters / roll, pitch & yaw are expressed in radians');
+    this.setTooltip(
+      'Move robot end effector pose to a (x, y, z, roll, pitch, yaw, frame_name) pose. x, y & z are expressed in meters / roll, pitch & yaw are expressed in radians'
+    );
     this.setHelpUrl('');
   }
 };
@@ -205,7 +209,9 @@ Blockly.Blocks['niryo_one_set_arm_max_speed'] = {
     this.setPreviousStatement(true, null);
     this.setNextStatement(true, null);
     this.setColour(movement_color);
-    this.setTooltip('Limit arm max velocity to a percentage of its maximum velocity. Should be between 1 & 100');
+    this.setTooltip(
+      'Limit arm max velocity to a percentage of its maximum velocity. Should be between 1 & 100'
+    );
     this.setHelpUrl('');
   }
 };
@@ -344,7 +350,9 @@ Blockly.Blocks['niryo_one_pick_from_pose'] = {
     this.setPreviousStatement(true, null);
     this.setNextStatement(true, null);
     this.setColour(movement_color);
-    this.setTooltip('Execute a picking from a pose. A picking is described as: going over the object, going down until height = z, grasping with tool, going back over the object');
+    this.setTooltip(
+      'Execute a picking from a pose. A picking is described as: going over the object, going down until height = z, grasping with tool, going back over the object'
+    );
     this.setHelpUrl('');
   }
 };
@@ -357,7 +365,9 @@ Blockly.Blocks['niryo_one_place_from_pose'] = {
     this.setPreviousStatement(true, null);
     this.setNextStatement(true, null);
     this.setColour(movement_color);
-    this.setTooltip('Execute a placing from a position. A placing is described as: going over the place, going down until height = z, releasing the object with tool, going back over the place');
+    this.setTooltip(
+      'Execute a placing from a position. A placing is described as: going over the place, going down until height = z, releasing the object with tool, going back over the place'
+    );
     this.setHelpUrl('');
   }
 };
@@ -637,7 +647,9 @@ Blockly.Blocks['niryo_one_activate_electromagnet'] = {
     this.setPreviousStatement(true, null);
     this.setNextStatement(true, null);
     this.setColour(tool_color);
-    this.setTooltip('Activate electromagnet associated to electromagnet_id on pin_id');
+    this.setTooltip(
+      'Activate electromagnet associated to electromagnet_id on pin_id'
+    );
     this.setHelpUrl('');
   }
 };
@@ -652,7 +664,9 @@ Blockly.Blocks['niryo_one_deactivate_electromagnet'] = {
     this.setPreviousStatement(true, null);
     this.setNextStatement(true, null);
     this.setColour(tool_color);
-    this.setTooltip('Deactivate electromagnet associated to electromagnet_id on pin_id');
+    this.setTooltip(
+      'Deactivate electromagnet associated to electromagnet_id on pin_id'
+    );
     this.setHelpUrl('');
   }
 };
@@ -745,7 +759,8 @@ Blockly.Blocks['niryo_one_vision_pick'] = {
     this.setColour(vision_color);
     this.setHelpUrl('');
     this.setTooltip(
-      'Picks the specified object from the workspace. This function has multiple phases: 1. detect object using the camera 2. prepare the current tool for picking 3. approach the object 4. move down to the correct picking pose 5. actuate the current tool 6. lift the object');
+      'Picks the specified object from the workspace. This function has multiple phases: 1. detect object using the camera 2. prepare the current tool for picking 3. approach the object 4. move down to the correct picking pose 5. actuate the current tool 6. lift the object'
+    );
     this.setInputsInline(false);
   }
 };
@@ -1173,15 +1188,13 @@ BlocklyPy['niryo_one_update_tool'] = function (block) {
 
 BlocklyPy['niryo_one_open_gripper'] = function (block) {
   var number_open_speed = block.getFieldValue('OPEN_SPEED');
-  var code =
-    'n.open_gripper( ' + number_open_speed + ')\n';
+  var code = 'n.open_gripper( ' + number_open_speed + ')\n';
   return code;
 };
 
 BlocklyPy['niryo_one_close_gripper'] = function (block) {
   var number_close_speed = block.getFieldValue('CLOSE_SPEED');
-  var code =
-    'n.close_gripper(' + number_close_speed + ')\n';
+  var code = 'n.close_gripper(' + number_close_speed + ')\n';
   return code;
 };
 
@@ -1205,10 +1218,7 @@ BlocklyPy['niryo_one_setup_electromagnet'] = function (block) {
   value_electromagnet_pin = value_electromagnet_pin
     .replace('(', '')
     .replace(')', '');
-  var code =
-    'n.setup_electromagnet(' +
-    value_electromagnet_pin +
-    ')\n';
+  var code = 'n.setup_electromagnet(' + value_electromagnet_pin + ')\n';
   return code;
 };
 
@@ -1222,10 +1232,7 @@ BlocklyPy['niryo_one_activate_electromagnet'] = function (block) {
   value_electromagnet_pin = value_electromagnet_pin
     .replace('(', '')
     .replace(')', '');
-  var code =
-    'n.activate_electromagnet(' +
-    value_electromagnet_pin +
-    ')\n';
+  var code = 'n.activate_electromagnet(' + value_electromagnet_pin + ')\n';
   return code;
 };
 
@@ -1239,10 +1246,7 @@ BlocklyPy['niryo_one_deactivate_electromagnet'] = function (block) {
   value_electromagnet_pin = value_electromagnet_pin
     .replace('(', '')
     .replace(')', '');
-  var code =
-    'n.deactivate_electromagnet(' +
-    value_electromagnet_pin +
-    ')\n';
+  var code = 'n.deactivate_electromagnet(' + value_electromagnet_pin + ')\n';
   return code;
 };
 

--- a/src/niryo_one_python_generators.js
+++ b/src/niryo_one_python_generators.js
@@ -1330,11 +1330,25 @@ Blockly.Blocks['niryo_one_conveyor_models'] = {
 
 Blockly.Blocks['niryo_one_conveyor_use'] = {
   init: function () {
-    this.appendDummyInput().appendField('Activate conveyor');
+    this.appendDummyInput().appendField('Activate conveyor and return its ID');
     this.setColour(conveyor_color);
     this.setOutput(true, 'String');
     this.setHelpUrl('');
     this.setTooltip('Activate a new conveyor and return its ID.');
+    this.setPreviousStatement(true, null);
+    this.setNextStatement(true, null);
+  }
+};
+
+Blockly.Blocks['niryo_one_conveyor_unset'] = {
+  init: function () {
+    this.appendValueInput('CONVEYOR_SWITCH')
+      .setCheck('niryo_one_conveyor_models')
+      .appendField('Remove conveyor');
+
+    this.setColour(conveyor_color);
+    this.setHelpUrl('');
+    this.setTooltip('Remove specific conveyor.');
     this.setPreviousStatement(true, null);
     this.setNextStatement(true, null);
   }
@@ -1369,6 +1383,34 @@ Blockly.Blocks['niryo_one_conveyor_control'] = {
   }
 };
 
+Blockly.Blocks['niryo_one_conveyor_run'] = {
+  init: function () {
+    this.appendValueInput('CONVEYOR_SWITCH')
+      .setCheck('niryo_one_conveyor_models')
+      .appendField('Run conveyor:');
+
+    this.appendValueInput('SPEED_PERCENT')
+      .setCheck('Number')
+      .appendField('with speed (%):');
+
+    this.appendDummyInput()
+      .appendField('in direction:')
+      .appendField(
+        new Blockly.FieldDropdown([
+          ['FORWARD', '1'],
+          ['BACKWARD', '-1']
+        ]),
+        'DIRECTION_SELECT'
+      );
+    this.setColour(conveyor_color);
+    this.setHelpUrl('');
+    this.setTooltip('Run conveyor');
+    this.setPreviousStatement(true, null);
+    this.setNextStatement(true, null);
+    this.setInputsInline(false);
+  }
+};
+
 Blockly.Blocks['niryo_one_conveyor_stop'] = {
   init: function () {
     this.appendValueInput('CONVEYOR_SWITCH')
@@ -1383,6 +1425,17 @@ Blockly.Blocks['niryo_one_conveyor_stop'] = {
   }
 };
 
+Blockly.Blocks['niryo_one_get_connected_conveyors_id'] = {
+  init: function () {
+    this.appendDummyInput().appendField('Get list of connected conveyors');
+    this.setOutput(true, null);
+    this.setColour(conveyor_color);
+    this.setPreviousStatement(true, null);
+    this.setNextStatement(true, null);
+    this.setHelpUrl('');
+    this.setTooltip('Conveyors directions available with Niryo One.');
+  }
+};
 /*
  * Generators
  */
@@ -2215,6 +2268,20 @@ BlocklyPy['niryo_one_conveyor_use'] = function (block) {
   return code;
 };
 
+BlocklyPy['niryo_one_conveyor_use'] = function (block) {
+  var code = 'n.set_conveyor()\n';
+  return code;
+};
+
+BlocklyPy['niryo_one_conveyor_unset'] = function (block) {
+  var conveyor_id =
+    BlocklyPy.valueToCode(block, 'CONVEYOR_SWITCH', BlocklyPy.ORDER_ATOMIC) ||
+    '(0)';
+  conveyor_id = conveyor_id.replace('(', '').replace(')', '');
+  var code = 'n.unset_conveyor(' + conveyor_id + ')\n';
+  return code;
+};
+
 BlocklyPy['niryo_one_conveyor_control'] = function (block) {
   var conveyor_id =
     BlocklyPy.valueToCode(block, 'CONVEYOR_SWITCH', BlocklyPy.ORDER_ATOMIC) ||
@@ -2236,12 +2303,38 @@ BlocklyPy['niryo_one_conveyor_control'] = function (block) {
   return code;
 };
 
+BlocklyPy['niryo_one_conveyor_run'] = function (block) {
+  var conveyor_id =
+    BlocklyPy.valueToCode(block, 'CONVEYOR_SWITCH', BlocklyPy.ORDER_ATOMIC) ||
+    '(0)';
+  conveyor_id = conveyor_id.replace('(', '').replace(')', '');
+  var speed_percent =
+    BlocklyPy.valueToCode(block, 'SPEED_PERCENT', BlocklyPy.ORDER_ATOMIC) ||
+    '(0)';
+  speed_percent = speed_percent.replace('(', '').replace(')', '');
+  var direction = block.getFieldValue('DIRECTION_SELECT');
+  var code =
+    'n.run_conveyor(' +
+    conveyor_id +
+    ', ' +
+    speed_percent +
+    ', ' +
+    direction +
+    ')\n';
+  return code;
+};
+
 BlocklyPy['niryo_one_conveyor_stop'] = function (block) {
   var conveyor_id =
     BlocklyPy.valueToCode(block, 'CONVEYOR_SWITCH', BlocklyPy.ORDER_ATOMIC) ||
     '(0)';
   conveyor_id = conveyor_id.replace('(', '').replace(')', '');
   var code = 'n.stop_conveyor(' + conveyor_id + ')\n';
+  return code;
+};
+
+BlocklyPy['niryo_one_get_connected_conveyors_id'] = function (block) {
+  var code = 'n.get_connected_conveyors_id()\n';
   return code;
 };
 
@@ -2860,11 +2953,23 @@ const TOOLBOX = {
         },
         {
           kind: 'BLOCK',
+          type: 'niryo_one_conveyor_unset'
+        },
+        {
+          kind: 'BLOCK',
           type: 'niryo_one_conveyor_control'
         },
         {
           kind: 'BLOCK',
+          type: 'niryo_one_conveyor_run'
+        },
+        {
+          kind: 'BLOCK',
           type: 'niryo_one_conveyor_stop'
+        },
+        {
+          kind: 'BLOCK',
+          type: 'niryo_one_get_connected_conveyors_id'
         }
       ]
     }

--- a/src/niryo_one_python_generators.js
+++ b/src/niryo_one_python_generators.js
@@ -794,7 +794,7 @@ Blockly.Blocks['niryo_one_save_pose'] = {
 Blockly.Blocks['niryo_one_delete_pose'] = {
   init: function () {
     this.appendValueInput('POSE_NAME')
-      .setCheck('String')
+      .setCheck(null)
       .appendField('Delete pose named');
     this.setPreviousStatement(true, null);
     this.setNextStatement(true, null);
@@ -810,6 +810,87 @@ Blockly.Blocks['niryo_one_get_saved_pose_list'] = {
     this.setOutput(true, null);
     this.setColour(movement_color);
     this.setTooltip('');
+    this.setHelpUrl('');
+  }
+};
+
+// Trajectories
+
+// Blockly.Blocks['niryo_one_trajectory'] = {
+//   // Create block which can get a trajectory (list of poses).
+// };
+
+Blockly.Blocks['niryo_one_get_trajectory_saved'] = {
+  init: function () {
+    this.appendValueInput('TRAJECTORY_NAME')
+      .setCheck('String')
+      .appendField('Get trajectory named');
+    this.setOutput(true, null);
+    this.setColour(movement_color);
+    this.setTooltip('Get trajectory saved in Niryo’s memory');
+    this.setHelpUrl('');
+  }
+};
+
+Blockly.Blocks['niryo_one_get_saved_trajectory_list'] = {
+  init: function () {
+    this.appendDummyInput().appendField('Get list of saved trajectories');
+    this.setOutput(true, null);
+    this.setColour(movement_color);
+    this.setTooltip('');
+    this.setHelpUrl('');
+  }
+};
+
+Blockly.Blocks['niryo_one_execute_registered_trajectory'] = {
+  init: function () {
+    this.appendValueInput('TRAJECTORY_NAME')
+      .setCheck('String')
+      .appendField('Execute trajectory named');
+    this.setOutput(true, null);
+    this.setColour(movement_color);
+    this.setTooltip('Execute trajectory from Niryo’s memory');
+    this.setHelpUrl('');
+  }
+};
+
+Blockly.Blocks['niryo_one_save_last_learned_trajectory'] = {
+  init: function () {
+    this.appendValueInput('TRAJECTORY_NAME')
+      .setCheck('String')
+      .appendField('Save last executed trajectory under name');
+    this.appendValueInput('TRAJECTORY_DESCRIPTION')
+      .setCheck('String')
+      .appendField('and description');
+    this.setColour(movement_color);
+    this.setInputsInline(true);
+    this.setPreviousStatement(true, null);
+    this.setNextStatement(true, null);
+    this.setTooltip('Save last user executed trajectory');
+    this.setHelpUrl('');
+  }
+};
+
+Blockly.Blocks['niryo_one_delete_trajectory'] = {
+  init: function () {
+    this.appendValueInput('TRAJECTORY_NAME')
+      .setCheck(null)
+      .appendField('Delete trajectory named');
+    this.setPreviousStatement(true, null);
+    this.setNextStatement(true, null);
+    this.setColour(movement_color);
+    this.setTooltip('Delete trajectory from Niryo’s memory');
+    this.setHelpUrl('');
+  }
+};
+
+Blockly.Blocks['niryo_one_clean_trajectory_memory'] = {
+  init: function () {
+    this.appendDummyInput().appendField('Clean trajectory memory');
+    this.setPreviousStatement(true, null);
+    this.setNextStatement(true, null);
+    this.setColour(movement_color);
+    this.setTooltip('Clean trajectory from Niryo’s memory');
     this.setHelpUrl('');
   }
 };
@@ -1629,7 +1710,7 @@ BlocklyPy['niryo_one_pick_and_place'] = function (block) {
     ', ' +
     dist_smoothing_value +
     ')\n';
-  return [code, BlocklyPy.ORDER_NONE];
+  return code;
 };
 
 BlocklyPy['niryo_one_jog_joints'] = function (block) {
@@ -1751,7 +1832,7 @@ BlocklyPy['niryo_one_get_saved_pose'] = function (block) {
     Blockly.Python.ORDER_ATOMIC
   );
   var code = 'n.get_saved_pose(' + value_pose_name + ')\n';
-  return [code, Blockly.Python.ORDER_NONE];
+  return code;
 };
 
 BlocklyPy['niryo_one_save_pose'] = function (block) {
@@ -1784,7 +1865,7 @@ BlocklyPy['niryo_one_save_pose'] = function (block) {
     ', ' +
     number_pose_yaw +
     ')\n';
-  return [code, Blockly.Python.ORDER_NONE];
+  return code;
 };
 
 BlocklyPy['niryo_one_delete_pose'] = function (block) {
@@ -1794,11 +1875,75 @@ BlocklyPy['niryo_one_delete_pose'] = function (block) {
     Blockly.Python.ORDER_ATOMIC
   );
   var code = 'n.delete_pose(' + pose_name + ')\n';
-  return [code, Blockly.Python.ORDER_NONE];
+  return code;
 };
 
 BlocklyPy['niryo_one_get_saved_pose_list'] = function (block) {
   var code = 'n.get_saved_pose_list()\n';
+  return code;
+};
+
+// Trajectories
+
+BlocklyPy['niryo_one_get_trajectory_saved'] = function (block) {
+  var value_trajectory_name = Blockly.Python.valueToCode(
+    block,
+    'TRAJECTORY_NAME',
+    Blockly.Python.ORDER_ATOMIC
+  );
+  var code = 'n.get_trajectory_saved(' + value_trajectory_name + ')\n';
+  return [code, Blockly.Python.ORDER_NONE];
+};
+
+BlocklyPy['niryo_one_get_saved_trajectory_list'] = function (block) {
+  var code = 'n.get_saved_trajectory_list()\n';
+  return code;
+};
+
+BlocklyPy['niryo_one_execute_registered_trajectory'] = function (block) {
+  var value_trajectory_name = Blockly.Python.valueToCode(
+    block,
+    'TRAJECTORY_NAME',
+    Blockly.Python.ORDER_ATOMIC
+  );
+  var code = 'n.execute_registered_trajectory(' + value_trajectory_name + ')\n';
+  return [code, Blockly.Python.ORDER_NONE];
+};
+
+BlocklyPy['niryo_one_save_last_learned_trajectory'] = function (block) {
+  var trajectory_name = Blockly.Python.valueToCode(
+    block,
+    'TRAJECTORY_NAME',
+    Blockly.Python.ORDER_ATOMIC
+  );
+
+  var trajectory_description = Blockly.Python.valueToCode(
+    block,
+    'TRAJECTORY_DESCRIPTION',
+    Blockly.Python.ORDER_ATOMIC
+  );
+
+  var code =
+    'n.save_last_learned_trajectory(' +
+    trajectory_name +
+    ', ' +
+    trajectory_description +
+    ')\n';
+  return code;
+};
+
+BlocklyPy['niryo_one_delete_trajectory'] = function (block) {
+  var trajectory_name = Blockly.Python.valueToCode(
+    block,
+    'TRAJECTORY_NAME',
+    Blockly.Python.ORDER_ATOMIC
+  );
+  var code = 'n.delete_trajectory(' + trajectory_name + ')\n';
+  return code;
+};
+
+BlocklyPy['niryo_one_clean_trajectory_memory'] = function (block) {
+  var code = 'n.clean_trajectory_memory()\n';
   return code;
 };
 
@@ -2545,10 +2690,10 @@ const TOOLBOX = {
           kind: 'BLOCK',
           type: 'niryo_one_place_from_pose'
         },
-        // {
-        //   kind: 'BLOCK',
-        //   type: 'niryo_one_pick_and_place'
-        // },
+        {
+          kind: 'BLOCK',
+          type: 'niryo_one_pick_and_place'
+        },
         {
           kind: 'BLOCK',
           type: 'niryo_one_jog_joints'
@@ -2588,6 +2733,30 @@ const TOOLBOX = {
         {
           kind: 'BLOCK',
           type: 'niryo_one_get_saved_pose_list'
+        },
+        {
+          kind: 'BLOCK',
+          type: 'niryo_one_get_trajectory_saved'
+        },
+        {
+          kind: 'BLOCK',
+          type: 'niryo_one_get_saved_trajectory_list'
+        },
+        {
+          kind: 'BLOCK',
+          type: 'niryo_one_execute_registered_trajectory'
+        },
+        {
+          kind: 'BLOCK',
+          type: 'niryo_one_save_last_learned_trajectory'
+        },
+        {
+          kind: 'BLOCK',
+          type: 'niryo_one_delete_trajectory'
+        },
+        {
+          kind: 'BLOCK',
+          type: 'niryo_one_clean_trajectory_memory'
         },
         {
           kind: 'BLOCK',

--- a/src/niryo_one_python_generators.js
+++ b/src/niryo_one_python_generators.js
@@ -858,6 +858,46 @@ Blockly.Blocks['niryo_one_execute_registered_trajectory'] = {
   }
 };
 
+Blockly.Blocks['niryo_one_execute_trajectory_from_poses'] = {
+  init: function () {
+    this.appendDummyInput().appendField('Execute trajectory from poses');
+    this.appendValueInput('POSE_1').setCheck('niryo_one_pose');
+    this.appendValueInput('POSE_2').setCheck('niryo_one_pose');
+    this.appendValueInput('POSE_3').setCheck('niryo_one_pose');
+    this.appendValueInput('DIST_SMOOTHING')
+      .setCheck('Number')
+      .appendField('with smoothing distance factor');
+    this.setPreviousStatement(true, null);
+    this.setNextStatement(true, null);
+    this.setColour(trajectory_color);
+    this.setTooltip(
+      'Execute trajectory from a list of poses. Distance smoothing refers to distance from waypoints before smoothing trajectory.'
+    );
+    this.setHelpUrl('');
+  }
+};
+
+Blockly.Blocks['niryo_one_save_trajectory'] = {
+  init: function () {
+    this.appendDummyInput().appendField('Save trajectory from joints');
+    // this.appendDummyInput().appendField('\n');
+    this.appendValueInput('JOINT_1').setCheck('niryo_one_joint');
+    this.appendValueInput('JOINT_2').setCheck('niryo_one_joint');
+    this.appendValueInput('JOINT_3').setCheck('niryo_one_joint');
+    this.appendValueInput('TRAJECTORY_NAME')
+      .setCheck('String')
+      .appendField('under name');
+    this.appendValueInput('TRAJECTORY_DESCRIPTION')
+      .setCheck('String')
+      .appendField('and description');
+    this.setColour(trajectory_color);
+    this.setPreviousStatement(true, null);
+    this.setNextStatement(true, null);
+    this.setTooltip('Save trajectory');
+    this.setHelpUrl('');
+  }
+};
+
 Blockly.Blocks['niryo_one_save_last_learned_trajectory'] = {
   init: function () {
     this.appendValueInput('TRAJECTORY_NAME')
@@ -1073,6 +1113,47 @@ Blockly.Blocks['niryo_one_gpio_select'] = {
       'GPIO_SELECT'
     );
     this.setOutput(true, 'niryo_one_gpio_select');
+    this.setColour(io_color);
+    this.setTooltip('');
+    this.setHelpUrl('');
+  }
+};
+
+Blockly.Blocks['niryo_one_do_di_select'] = {
+  init: function () {
+    this.appendDummyInput().appendField(
+      new Blockly.FieldDropdown([
+        ['DO1', 'DO1'],
+        ['DO2', 'DO2'],
+        ['DO3', 'DO3'],
+        ['DO4', 'DO4'],
+        ['DI1', 'DI1'],
+        ['DI2', 'DI2'],
+        ['DI3', 'DI3'],
+        ['DI4', 'DI4'],
+        ['DI5', 'DI5']
+      ]),
+      'DO_DI_SELECT'
+    );
+    this.setOutput(true, 'niryo_one_do_di_select');
+    this.setColour(io_color);
+    this.setTooltip('');
+    this.setHelpUrl('');
+  }
+};
+
+Blockly.Blocks['niryo_one_ao_ai_select'] = {
+  init: function () {
+    this.appendDummyInput().appendField(
+      new Blockly.FieldDropdown([
+        ['AO1', 'AO1'],
+        ['AO2', 'AO2'],
+        ['AI1', 'AI1'],
+        ['AI2', 'AI2']
+      ]),
+      'DO_DI_SELECT'
+    );
+    this.setOutput(true, 'niryo_one_ao_ai_select');
     this.setColour(io_color);
     this.setTooltip('');
     this.setHelpUrl('');
@@ -2929,6 +3010,97 @@ BlocklyPy['niryo_one_execute_registered_trajectory'] = function (block) {
   return [code, BlocklyPy.ORDER_NONE];
 };
 
+BlocklyPy['niryo_one_execute_trajectory_from_poses'] = function (block) {
+  var value_pose_1 = BlocklyPy.valueToCode(
+    block,
+    'POSE_1',
+    BlocklyPy.ORDER_ATOMIC
+  );
+  value_pose_1 = value_pose_1.replace('(', '').replace(')', '');
+
+  var value_pose_2 = BlocklyPy.valueToCode(
+    block,
+    'POSE_2',
+    BlocklyPy.ORDER_ATOMIC
+  );
+  value_pose_2 = value_pose_2.replace('(', '').replace(')', '');
+
+  var value_pose_3 = BlocklyPy.valueToCode(
+    block,
+    'POSE_3',
+    BlocklyPy.ORDER_ATOMIC
+  );
+  value_pose_3 = value_pose_3.replace('(', '').replace(')', '');
+
+  var dist_smoothing_value = BlocklyPy.valueToCode(
+    block,
+    'DIST_SMOOTHING',
+    BlocklyPy.ORDER_ATOMIC
+  );
+  dist_smoothing_value = dist_smoothing_value.replace('(', '').replace(')', '');
+
+  var code =
+    'n.execute_trajectory_from_poses([' +
+    value_pose_1 +
+    ', ' +
+    value_pose_2 +
+    ', ' +
+    value_pose_3 +
+    '], ' +
+    dist_smoothing_value +
+    ')\n';
+  return code;
+};
+
+BlocklyPy['niryo_one_save_trajectory'] = function (block) {
+  var value_joint_1 = BlocklyPy.valueToCode(
+    block,
+    'JOINT_1',
+    BlocklyPy.ORDER_ATOMIC
+  );
+  value_joint_1 = value_joint_1.replace('(', '').replace(')', '');
+
+  var value_joint_2 = BlocklyPy.valueToCode(
+    block,
+    'JOINT_2',
+    BlocklyPy.ORDER_ATOMIC
+  );
+  value_joint_2 = value_joint_2.replace('(', '').replace(')', '');
+
+  var value_joint_3 = BlocklyPy.valueToCode(
+    block,
+    'JOINT_3',
+    BlocklyPy.ORDER_ATOMIC
+  );
+  value_joint_3 = value_joint_3.replace('(', '').replace(')', '');
+
+  var trajectory_name = BlocklyPy.valueToCode(
+    block,
+    'TRAJECTORY_NAME',
+    BlocklyPy.ORDER_ATOMIC
+  );
+
+  var trajectory_description = BlocklyPy.valueToCode(
+    block,
+    'TRAJECTORY_DESCRIPTION',
+    BlocklyPy.ORDER_ATOMIC
+  );
+
+  var code =
+    'n.save_trajectory([' +
+    value_joint_1 +
+    ', ' +
+    value_joint_2 +
+    ', ' +
+    value_joint_3 +
+    '], ' +
+    trajectory_name +
+    ', ' +
+    trajectory_description +
+    ')\n';
+  return code;
+};
+
 BlocklyPy['niryo_one_save_last_learned_trajectory'] = function (block) {
   var trajectory_name = BlocklyPy.valueToCode(
     block,
@@ -3256,6 +3428,18 @@ BlocklyPy['niryo_one_analog_read'] = function (block) {
 BlocklyPy['niryo_one_gpio_select'] = function (block) {
   var dropdown_gpio_select = block.getFieldValue('GPIO_SELECT');
   var code = dropdown_gpio_select;
+  return [code, BlocklyPy.ORDER_NONE];
+};
+
+BlocklyPy['niryo_one_do_di_select'] = function (block) {
+  var dropdown_do_di_select = block.getFieldValue('DO_DI_SELECT');
+  var code = dropdown_do_di_select;
+  return [code, BlocklyPy.ORDER_NONE];
+};
+
+BlocklyPy['niryo_one_ao_ai_select'] = function (block) {
+  var dropdown_ao_ai_select = block.getFieldValue('AO_AI_SELECT');
+  var code = dropdown_ao_ai_select;
   return [code, BlocklyPy.ORDER_NONE];
 };
 
@@ -4869,6 +5053,14 @@ const TOOLBOX = {
         },
         {
           kind: 'BLOCK',
+          type: 'niryo_one_execute_trajectory_from_poses'
+        },
+        {
+          kind: 'BLOCK',
+          type: 'niryo_one_save_trajectory'
+        },
+        {
+          kind: 'BLOCK',
           type: 'niryo_one_save_last_learned_trajectory'
         },
         {
@@ -4918,6 +5110,14 @@ const TOOLBOX = {
         {
           kind: 'BLOCK',
           type: 'niryo_one_gpio_select'
+        },
+        {
+          kind: 'BLOCK',
+          type: 'niryo_one_do_di_select'
+        },
+        {
+          kind: 'BLOCK',
+          type: 'niryo_one_ao_ai_select'
         },
         {
           kind: 'BLOCK',

--- a/src/niryo_one_python_generators.js
+++ b/src/niryo_one_python_generators.js
@@ -118,7 +118,7 @@ Blockly.Blocks['niryo_one_move_joints'] = {
     this.setPreviousStatement(true, null);
     this.setNextStatement(true, null);
     this.setColour(movement_color);
-    this.setTooltip('Give all 6 joints to move the robot');
+    this.setTooltip('Give all 6 joints to move the robot. Joints are expressed in radians.');
     this.setHelpUrl('');
   }
 };
@@ -161,7 +161,7 @@ Blockly.Blocks['niryo_one_move_pose'] = {
     this.setPreviousStatement(true, null);
     this.setNextStatement(true, null);
     this.setColour(movement_color);
-    this.setTooltip('');
+    this.setTooltip('Move robot end effector pose to a (x, y, z, roll, pitch, yaw, frame_name) pose. x, y & z are expressed in meters / roll, pitch & yaw are expressed in radians');
     this.setHelpUrl('');
   }
 };
@@ -190,7 +190,7 @@ Blockly.Blocks['niryo_one_shift_pose'] = {
     this.setPreviousStatement(true, null);
     this.setNextStatement(true, null);
     this.setColour(movement_color);
-    this.setTooltip('');
+    this.setTooltip('Shift robot end effector pose along one axis');
     this.setHelpUrl('');
   }
 };
@@ -205,7 +205,7 @@ Blockly.Blocks['niryo_one_set_arm_max_speed'] = {
     this.setPreviousStatement(true, null);
     this.setNextStatement(true, null);
     this.setColour(movement_color);
-    this.setTooltip('');
+    this.setTooltip('Limit arm max velocity to a percentage of its maximum velocity. Should be between 1 & 100');
     this.setHelpUrl('');
   }
 };
@@ -223,14 +223,22 @@ Blockly.Blocks['niryo_one_calibrate_auto'] = {
   }
 };
 
-Blockly.Blocks['niryo_one_calibrate_manual'] = {
+Blockly.Blocks['niryo_one_calibrate'] = {
   init: function () {
-    this.appendDummyInput().appendField('Calibrate motors (manual)');
+    this.appendDummyInput()
+      .appendField(
+        new Blockly.FieldDropdown([
+          ['Auto', 'Auto'],
+          ['Manual', 'Manual']
+        ]),
+        'CALIBRATE_MODE'
+      )
+      .appendField('calibrate mode');
     this.setPreviousStatement(true, null);
     this.setNextStatement(true, null);
     this.setColour(movement_color);
     this.setTooltip(
-      'Will manually calibrate motors (robot needs to be in home position). If already calibrated, will do nothing.'
+      'Will auto or manually calibrate motors (robot needs to be in home position for manual calibration). If already calibrated, will do nothing.'
     );
     this.setHelpUrl('');
   }
@@ -250,7 +258,7 @@ Blockly.Blocks['niryo_one_activate_learning_mode'] = {
     this.setPreviousStatement(true, null);
     this.setNextStatement(true, null);
     this.setColour(movement_color);
-    this.setTooltip('');
+    this.setTooltip('Set learning mode if param is True, else turn it off.');
     this.setHelpUrl('');
   }
 };
@@ -336,7 +344,7 @@ Blockly.Blocks['niryo_one_pick_from_pose'] = {
     this.setPreviousStatement(true, null);
     this.setNextStatement(true, null);
     this.setColour(movement_color);
-    this.setTooltip('Pick an object at a pose given');
+    this.setTooltip('Execute a picking from a pose. A picking is described as: going over the object, going down until height = z, grasping with tool, going back over the object');
     this.setHelpUrl('');
   }
 };
@@ -349,7 +357,7 @@ Blockly.Blocks['niryo_one_place_from_pose'] = {
     this.setPreviousStatement(true, null);
     this.setNextStatement(true, null);
     this.setColour(movement_color);
-    this.setTooltip('Place an object at a pose given');
+    this.setTooltip('Execute a placing from a position. A placing is described as: going over the place, going down until height = z, releasing the object with tool, going back over the place');
     this.setHelpUrl('');
   }
 };
@@ -499,11 +507,11 @@ Blockly.Blocks['niryo_one_tool_select'] = {
   init: function () {
     this.appendDummyInput().appendField(
       new Blockly.FieldDropdown([
-        ['Standard gripper', 'TOOL_GRIPPER_1_ID'],
-        ['Large gripper', 'TOOL_GRIPPER_2_ID'],
-        ['Adaptive gripper ', 'TOOL_GRIPPER_3_ID'],
-        ['electromagnet 1', 'TOOL_ELECTROMAGNET_1_ID'],
-        ['vacuum pump 1', 'TOOL_VACUUM_PUMP_1_ID']
+        ['Standard gripper', 'GRIPPER_1_ID'],
+        ['Large gripper', 'GRIPPER_2_ID'],
+        ['Adaptive gripper ', 'GRIPPER_3_ID'],
+        ['Electromagnet 1', 'ELECTROMAGNET_1_ID'],
+        ['Vacuum pump 1', 'VACUUM_PUMP_1_ID']
       ]),
       'TOOL_SELECT'
     );
@@ -514,12 +522,9 @@ Blockly.Blocks['niryo_one_tool_select'] = {
   }
 };
 
-Blockly.Blocks['niryo_one_change_tool'] = {
+Blockly.Blocks['niryo_one_update_tool'] = {
   init: function () {
-    this.appendValueInput('NEW_TOOL_ID')
-      .setCheck('niryo_one_tool_select')
-      .appendField('Change tool to');
-    this.setInputsInline(true);
+    this.appendDummyInput().appendField('Update tool');
     this.setPreviousStatement(true, null);
     this.setNextStatement(true, null);
     this.setColour(tool_color);
@@ -528,24 +533,21 @@ Blockly.Blocks['niryo_one_change_tool'] = {
   }
 };
 
-Blockly.Blocks['niryo_one_detach_tool'] = {
-  init: function () {
-    this.appendDummyInput().appendField('Detach current tool');
-    this.setPreviousStatement(true, null);
-    this.setNextStatement(true, null);
-    this.setColour(tool_color);
-    this.setTooltip('');
-    this.setHelpUrl('');
-  }
-};
+// Blockly.Blocks['niryo_one_detach_tool'] = {
+//   init: function () {
+//     this.appendDummyInput().appendField('Detach current tool');
+//     this.setPreviousStatement(true, null);
+//     this.setNextStatement(true, null);
+//     this.setColour(tool_color);
+//     this.setTooltip('');
+//     this.setHelpUrl('');
+//   }
+// };
 
 Blockly.Blocks['niryo_one_open_gripper'] = {
   init: function () {
-    this.appendValueInput('OPEN_GRIPPER_ID')
-      .setCheck('niryo_one_tool_select')
-      .appendField('Open Gripper');
     this.appendDummyInput()
-      .appendField('at speed')
+      .appendField('Open gripper at speed')
       .appendField(
         new Blockly.FieldDropdown([
           ['1/5', '100'],
@@ -567,11 +569,8 @@ Blockly.Blocks['niryo_one_open_gripper'] = {
 
 Blockly.Blocks['niryo_one_close_gripper'] = {
   init: function () {
-    this.appendValueInput('CLOSE_GRIPPER_ID')
-      .setCheck('niryo_one_tool_select')
-      .appendField('Close Gripper');
     this.appendDummyInput()
-      .appendField('at speed')
+      .appendField('Close gripper at speed')
       .appendField(
         new Blockly.FieldDropdown([
           ['1/5', '100'],
@@ -593,24 +592,18 @@ Blockly.Blocks['niryo_one_close_gripper'] = {
 
 Blockly.Blocks['niryo_one_pull_air_vacuum_pump'] = {
   init: function () {
-    this.appendValueInput('PULL_AIR_VACUUM_PUMP_ID')
-      .setCheck('niryo_one_tool_select')
-      .appendField('Pull air with Vacuum Pump');
-    this.setInputsInline(true);
+    this.appendDummyInput().appendField('Pull air with Vacuum Pump');
     this.setPreviousStatement(true, null);
     this.setNextStatement(true, null);
     this.setColour(tool_color);
-    this.setTooltip('');
+    this.setTooltip('Pull air of vacuum pump.');
     this.setHelpUrl('');
   }
 };
 
 Blockly.Blocks['niryo_one_push_air_vacuum_pump'] = {
   init: function () {
-    this.appendValueInput('PUSH_AIR_VACUUM_PUMP_ID')
-      .setCheck('niryo_one_tool_select')
-      .appendField('Push air with Vacuum Pump');
-    this.setInputsInline(true);
+    this.appendDummyInput().appendField('Push air with Vacuum Pump');
     this.setPreviousStatement(true, null);
     this.setNextStatement(true, null);
     this.setColour(tool_color);
@@ -621,54 +614,45 @@ Blockly.Blocks['niryo_one_push_air_vacuum_pump'] = {
 
 Blockly.Blocks['niryo_one_setup_electromagnet'] = {
   init: function () {
-    this.appendValueInput('SETUP_ELECTROMAGNET_ID')
-      .setCheck('niryo_one_tool_select')
-      .appendField('Setup Electromagnet');
     this.appendValueInput('SETUP_ELECTROMAGNET_PIN')
       .setCheck('niryo_one_gpio_select')
       .setAlign(Blockly.ALIGN_RIGHT)
-      .appendField('with pin');
+      .appendField('Setup Electromagnet on pin');
     this.setInputsInline(true);
     this.setPreviousStatement(true, null);
     this.setNextStatement(true, null);
     this.setColour(tool_color);
-    this.setTooltip('');
+    this.setTooltip('Setup electromagnet on pin');
     this.setHelpUrl('');
   }
 };
 
 Blockly.Blocks['niryo_one_activate_electromagnet'] = {
   init: function () {
-    this.appendValueInput('ACTIVATE_ELECTROMAGNET_ID')
-      .setCheck('niryo_one_tool_select')
-      .appendField('Activate Electromagnet');
     this.appendValueInput('ACTIVATE_ELECTROMAGNET_PIN')
       .setCheck('niryo_one_gpio_select')
       .setAlign(Blockly.ALIGN_RIGHT)
-      .appendField('with pin');
+      .appendField('Activate Electromagnet on pin');
     this.setInputsInline(true);
     this.setPreviousStatement(true, null);
     this.setNextStatement(true, null);
     this.setColour(tool_color);
-    this.setTooltip('');
+    this.setTooltip('Activate electromagnet associated to electromagnet_id on pin_id');
     this.setHelpUrl('');
   }
 };
 
 Blockly.Blocks['niryo_one_deactivate_electromagnet'] = {
   init: function () {
-    this.appendValueInput('DEACTIVATE_ELECTROMAGNET_ID')
-      .setCheck('niryo_one_tool_select')
-      .appendField('Deactivate Electromagnet');
     this.appendValueInput('DEACTIVATE_ELECTROMAGNET_PIN')
       .setCheck('niryo_one_gpio_select')
       .setAlign(Blockly.ALIGN_RIGHT)
-      .appendField('with pin');
+      .appendField('Deactivate Electromagnet on pin');
     this.setInputsInline(true);
     this.setPreviousStatement(true, null);
     this.setNextStatement(true, null);
     this.setColour(tool_color);
-    this.setTooltip('');
+    this.setTooltip('Deactivate electromagnet associated to electromagnet_id on pin_id');
     this.setHelpUrl('');
   }
 };
@@ -699,19 +683,6 @@ Blockly.Blocks['niryo_one_comment'] = {
     this.setNextStatement(true, null);
     this.setColour(utility_color);
     this.setTooltip('This block will not be executed.');
-    this.setHelpUrl('');
-  }
-};
-
-Blockly.Blocks['niryo_one_break_point'] = {
-  init: function () {
-    this.appendDummyInput().appendField('Break Point');
-    this.setPreviousStatement(true, null);
-    this.setNextStatement(true, null);
-    this.setColour(utility_color);
-    this.setTooltip(
-      "Stop the execution of the program. Press 'Play' to resume."
-    );
     this.setHelpUrl('');
   }
 };
@@ -774,8 +745,7 @@ Blockly.Blocks['niryo_one_vision_pick'] = {
     this.setColour(vision_color);
     this.setHelpUrl('');
     this.setTooltip(
-      'Pick an object of SHAPE / COLOR  given, with gripper close position at HEIGHT_OFFSET cm.'
-    );
+      'Picks the specified object from the workspace. This function has multiple phases: 1. detect object using the camera 2. prepare the current tool for picking 3. approach the object 4. move down to the correct picking pose 5. actuate the current tool 6. lift the object');
     this.setInputsInline(false);
   }
 };
@@ -822,13 +792,11 @@ Blockly.Blocks['niryo_one_conveyor_models'] = {
 
 Blockly.Blocks['niryo_one_conveyor_use'] = {
   init: function () {
-    this.appendValueInput('CONVEYOR_SWITCH')
-      .setCheck('niryo_one_conveyor_models')
-      .appendField('Use conveyor:');
-
+    this.appendDummyInput().appendField('Activate conveyor');
     this.setColour(conveyor_color);
+    this.setOutput(true, 'String');
     this.setHelpUrl('');
-    this.setTooltip('Allow the conveyor to be controlled via Niryo One.');
+    this.setTooltip('Activate a new conveyor and return its ID.');
     this.setPreviousStatement(true, null);
     this.setNextStatement(true, null);
   }
@@ -904,6 +872,7 @@ class niryo_connect():
     return self.n
   def __exit__(self):
     self.n.close_connection()
+
 `;
 
 BlocklyPy['niryo_one_move_joints'] = function (block) {
@@ -985,14 +954,15 @@ BlocklyPy['niryo_one_calibrate_auto'] = function (block) {
   return code;
 };
 
-BlocklyPy['niryo_one_calibrate_manual'] = function (block) {
-  var code = 'n.calibrate_manual()\n';
+BlocklyPy['niryo_one_calibrate'] = function (block) {
+  var dropdown_calibrate_mode = block.getFieldValue('CALIBRATE_MODE');
+  var code = 'n.calibrate(' + dropdown_calibrate_mode + ')\n';
   return code;
 };
 
 BlocklyPy['niryo_one_activate_learning_mode'] = function (block) {
   var dropdown_learning_mode_value = block.getFieldValue('LEARNING_MODE_VALUE');
-  var code = 'n.activate_learning_mode(' + dropdown_learning_mode_value + ')\n';
+  var code = 'n.set_learning_mode(' + dropdown_learning_mode_value + ')\n';
   return code;
 };
 
@@ -1129,7 +1099,7 @@ BlocklyPy['niryo_one_set_pin_mode'] = function (block) {
   value_pin = value_pin.replace('(', '').replace(')', '');
   var dropdown_pin_mode_select = block.getFieldValue('PIN_MODE_SELECT');
   var code =
-    'n.pin_mode(' + value_pin + ', ' + dropdown_pin_mode_select + ')\n';
+    'n.set_pin_mode(' + value_pin + ', ' + dropdown_pin_mode_select + ')\n';
   return code;
 };
 
@@ -1190,76 +1160,42 @@ BlocklyPy['niryo_one_tool_select'] = function (block) {
   return [code, BlocklyPy.ORDER_NONE];
 };
 
-BlocklyPy['niryo_one_change_tool'] = function (block) {
-  var value_tool_name =
-    BlocklyPy.valueToCode(block, 'NEW_TOOL_ID', BlocklyPy.ORDER_ATOMIC) ||
-    '(TOOL_NONE)';
-  value_tool_name = value_tool_name.replace('(', '').replace(')', '');
-  var code = 'n.change_tool(' + value_tool_name + ')\n';
+BlocklyPy['niryo_one_update_tool'] = function (block) {
+  var code = 'n.update_tool()\n';
   return code;
 };
 
-BlocklyPy['niryo_one_detach_tool'] = function (block) {
-  var code = 'n.change_tool(0)\n';
-  return code;
-};
+//  new function corresponds to release_with_tool (made in pair with grasp_with_tool)
+//  BlocklyPy['niryo_one_detach_tool'] = function (block) {
+//   var code = 'n.change_tool(0)\n';
+//   return code;
+// };
 
 BlocklyPy['niryo_one_open_gripper'] = function (block) {
-  var value_gripper_id =
-    BlocklyPy.valueToCode(block, 'OPEN_GRIPPER_ID', BlocklyPy.ORDER_ATOMIC) ||
-    '(TOOL_NONE)';
-  value_gripper_id = value_gripper_id.replace('(', '').replace(')', '');
   var number_open_speed = block.getFieldValue('OPEN_SPEED');
   var code =
-    'n.open_gripper(' + value_gripper_id + ', ' + number_open_speed + ')\n';
+    'n.open_gripper( ' + number_open_speed + ')\n';
   return code;
 };
 
 BlocklyPy['niryo_one_close_gripper'] = function (block) {
-  var value_gripper_id =
-    BlocklyPy.valueToCode(block, 'CLOSE_GRIPPER_ID', BlocklyPy.ORDER_ATOMIC) ||
-    '(TOOL_NONE)';
-  value_gripper_id = value_gripper_id.replace('(', '').replace(')', '');
   var number_close_speed = block.getFieldValue('CLOSE_SPEED');
   var code =
-    'n.close_gripper(' + value_gripper_id + ', ' + number_close_speed + ')\n';
+    'n.close_gripper(' + number_close_speed + ')\n';
   return code;
 };
 
 BlocklyPy['niryo_one_pull_air_vacuum_pump'] = function (block) {
-  var value_vacuum_pump_id =
-    BlocklyPy.valueToCode(
-      block,
-      'PULL_AIR_VACUUM_PUMP_ID',
-      BlocklyPy.ORDER_ATOMIC
-    ) || '(TOOL_NONE)';
-  value_vacuum_pump_id = value_vacuum_pump_id.replace('(', '').replace(')', '');
-  var code = 'n.pull_air_vacuum_pump(' + value_vacuum_pump_id + ')\n';
+  var code = 'n.pull_air_vacuum_pump()\n';
   return code;
 };
 
 BlocklyPy['niryo_one_push_air_vacuum_pump'] = function (block) {
-  var value_vacuum_pump_id =
-    BlocklyPy.valueToCode(
-      block,
-      'PUSH_AIR_VACUUM_PUMP_ID',
-      BlocklyPy.ORDER_ATOMIC
-    ) || '(TOOL_NONE)';
-  value_vacuum_pump_id = value_vacuum_pump_id.replace('(', '').replace(')', '');
-  var code = 'n.push_air_vacuum_pump(' + value_vacuum_pump_id + ')\n';
+  var code = 'n.push_air_vacuum_pump()\n';
   return code;
 };
 
 BlocklyPy['niryo_one_setup_electromagnet'] = function (block) {
-  var value_electromagnet_id =
-    BlocklyPy.valueToCode(
-      block,
-      'SETUP_ELECTROMAGNET_ID',
-      BlocklyPy.ORDER_ATOMIC
-    ) || '(TOOL_NONE)';
-  value_electromagnet_id = value_electromagnet_id
-    .replace('(', '')
-    .replace(')', '');
   var value_electromagnet_pin =
     BlocklyPy.valueToCode(
       block,
@@ -1271,23 +1207,12 @@ BlocklyPy['niryo_one_setup_electromagnet'] = function (block) {
     .replace(')', '');
   var code =
     'n.setup_electromagnet(' +
-    value_electromagnet_id +
-    ', ' +
     value_electromagnet_pin +
     ')\n';
   return code;
 };
 
 BlocklyPy['niryo_one_activate_electromagnet'] = function (block) {
-  var value_electromagnet_id =
-    BlocklyPy.valueToCode(
-      block,
-      'ACTIVATE_ELECTROMAGNET_ID',
-      BlocklyPy.ORDER_ATOMIC
-    ) || '(TOOL_NONE)';
-  value_electromagnet_id = value_electromagnet_id
-    .replace('(', '')
-    .replace(')', '');
   var value_electromagnet_pin =
     BlocklyPy.valueToCode(
       block,
@@ -1299,23 +1224,12 @@ BlocklyPy['niryo_one_activate_electromagnet'] = function (block) {
     .replace(')', '');
   var code =
     'n.activate_electromagnet(' +
-    value_electromagnet_id +
-    ', ' +
     value_electromagnet_pin +
     ')\n';
   return code;
 };
 
 BlocklyPy['niryo_one_deactivate_electromagnet'] = function (block) {
-  var value_electromagnet_id =
-    BlocklyPy.valueToCode(
-      block,
-      'DEACTIVATE_ELECTROMAGNET_ID',
-      BlocklyPy.ORDER_ATOMIC
-    ) || '(TOOL_NONE)';
-  value_electromagnet_id = value_electromagnet_id
-    .replace('(', '')
-    .replace(')', '');
   var value_electromagnet_pin =
     BlocklyPy.valueToCode(
       block,
@@ -1327,8 +1241,6 @@ BlocklyPy['niryo_one_deactivate_electromagnet'] = function (block) {
     .replace(')', '');
   var code =
     'n.deactivate_electromagnet(' +
-    value_electromagnet_id +
-    ', ' +
     value_electromagnet_pin +
     ')\n';
   return code;
@@ -1347,11 +1259,6 @@ BlocklyPy['niryo_one_sleep'] = function (block) {
 BlocklyPy['niryo_one_comment'] = function (block) {
   var text_comment_text = block.getFieldValue('COMMENT_TEXT');
   var code = ' #' + text_comment_text + '\n';
-  return code;
-};
-
-BlocklyPy['niryo_one_break_point'] = function (block) {
-  var code = 'n.break_point()\n';
   return code;
 };
 
@@ -1443,8 +1350,8 @@ BlocklyPy['niryo_one_vision_is_object_detected'] = function (block) {
 
 BlocklyPy['niryo_one_conveyor_models'] = function (block) {
   const conveyor_id_map = {
-    CONVEYOR_1: 6,
-    CONVEYOR_2: 7
+    CONVEYOR_1: -1,
+    CONVEYOR_2: -2
   };
   var conveyor_model_id = block.getFieldValue('CONVEYOR_SELECT');
   var code = conveyor_id_map[conveyor_model_id];
@@ -1452,11 +1359,7 @@ BlocklyPy['niryo_one_conveyor_models'] = function (block) {
 };
 
 BlocklyPy['niryo_one_conveyor_use'] = function (block) {
-  var conveyor_id =
-    BlocklyPy.valueToCode(block, 'CONVEYOR_SWITCH', BlocklyPy.ORDER_ATOMIC) ||
-    '(0)';
-  conveyor_id = conveyor_id.replace('(', '').replace(')', '');
-  var code = 'n.set_conveyor(' + conveyor_id + ', True)\n';
+  var code = 'n.set_conveyor()\n';
   return code;
 };
 
@@ -1486,7 +1389,7 @@ BlocklyPy['niryo_one_conveyor_stop'] = function (block) {
     BlocklyPy.valueToCode(block, 'CONVEYOR_SWITCH', BlocklyPy.ORDER_ATOMIC) ||
     '(0)';
   conveyor_id = conveyor_id.replace('(', '').replace(')', '');
-  var code = 'n.control_conveyor(' + conveyor_id + ', False, 0, 1)\n';
+  var code = 'n.stop_conveyor(' + conveyor_id + ')\n';
   return code;
 };
 
@@ -1873,7 +1776,7 @@ const TOOLBOX = {
         },
         {
           kind: 'BLOCK',
-          type: 'niryo_one_calibrate_manual'
+          type: 'niryo_one_calibrate'
         },
         {
           kind: 'BLOCK',
@@ -1941,12 +1844,12 @@ const TOOLBOX = {
         },
         {
           kind: 'BLOCK',
-          type: 'niryo_one_change_tool'
+          type: 'niryo_one_update_tool'
         },
-        {
-          kind: 'BLOCK',
-          type: 'niryo_one_detach_tool'
-        },
+        // {
+        //   kind: 'BLOCK',
+        //   type: 'niryo_one_detach_tool'
+        // },
         {
           kind: 'BLOCK',
           type: 'niryo_one_open_gripper'
@@ -1982,10 +1885,6 @@ const TOOLBOX = {
         {
           kind: 'BLOCK',
           type: 'niryo_one_comment'
-        },
-        {
-          kind: 'BLOCK',
-          type: 'niryo_one_break_point'
         },
         {
           kind: 'BLOCK',

--- a/yarn.lock
+++ b/yarn.lock
@@ -3737,10 +3737,10 @@ jsprim@^1.2.2:
     json-schema "0.4.0"
     verror "1.10.0"
 
-jupyterlab-blockly@^0.1.0-alpha.4:
-  version "0.1.0-alpha.4"
-  resolved "https://registry.yarnpkg.com/jupyterlab-blockly/-/jupyterlab-blockly-0.1.0-alpha.4.tgz#862d8a991c0fd61d45892c6abb7d912261cffcfb"
-  integrity sha512-FjdObiG/TKnruG8sQlIXo0ewDkaO694d5iKbPIeJj3raij2VWJWSgOiSRJU5uSIKD0tJJbk8c7vDEgEzpTZ44Q==
+jupyterlab-blockly@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/jupyterlab-blockly/-/jupyterlab-blockly-0.1.0.tgz#9c5d388f96d6cec57859d04868c6976c5db89170"
+  integrity sha512-SAmoM9imtbHONnu9BQNiNSto/cuS2agPbQ4FSOB7iOLDj4XOZClxCOspPO77hGQFODU/6guYB0uYsis/7Jrdbg==
   dependencies:
     "@jupyterlab/apputils" "^3.4"
     "@jupyterlab/cells" "^3.4"


### PR DESCRIPTION
Updated all already existing Niryo One blocks to match the latest API updates in `pyniryo`. Also updated the version of `jupyterlab-blockly` to `v0.1.0`. 

In the latest version of the `pyniryo` API there were several new blocks added, specifically in the following categories: 
- [x] Connection & multi-purpose functions
- [x] Joints & Pose
- [x] Trajectories
- [x] Dynamic frames
- [x] Tools
- [x] Hardware
- [x] Conveyor
- [x] Led Ring
- [x] Sound
- [x] Vision




















