### PR TITLE
Update repository links for new organisation

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,9 +10,9 @@
     "Niryo",
     "Niryo-One"
   ],
-  "homepage": "https://github.com/QuantStack/jupyterlab-niryo-one",
+  "homepage": "https://github.com/jupyter-robotics/jupyterlab-niryo-one",
   "bugs": {
-    "url": "https://github.com/QuantStack/jupyterlab-niryo-one/issues"
+    "url": "https://github.com/jupyter-robotics/jupyterlab-niryo-one/issues"
   },
   "license": "BSD-3-Clause",
   "author": {
@@ -28,7 +28,7 @@
   "style": "style/index.css",
   "repository": {
     "type": "git",
-    "url": "https://github.com/QuantStack/jupyterlab-niryo-one.git"
+    "url": "https://github.com/jupyter-robotics/jupyterlab-niryo-one.git"
   },
   "scripts": {
     "build": "jlpm build:lib && jlpm build:labextension:dev",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,8 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
 ]
 dependencies = [
-    "jupyterlab-blockly>=0.3.2,<0.4"
+    "jupyterlab-blockly>=0.3.2,<0.4",
+    "pyniryo>=1.1.2,<2"
 ]
 dynamic = ["version", "description", "authors", "urls", "keywords"]
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,18 +1,17 @@
 // @ts-check
 
 module.exports = /** @type { import('webpack').Configuration } */ ({
-    devtool: 'source-map',
-    module: {
-      rules: [
-        // Load Blockly source maps.
-        {
-          test: /(blockly\/.*\.js)$/,
-          use: [require.resolve('source-map-loader')],
-          enforce: 'pre'
-        }
-      ].filter(Boolean)
-    },
-    // https://github.com/google/blockly-samples/blob/9974e85becaa8ad17e35b588b95391c85865dafd/plugins/dev-scripts/config/webpack.config.js#L118-L120
-    ignoreWarnings: [/Failed to parse source map/]
-  });
-  
+  devtool: 'source-map',
+  module: {
+    rules: [
+      // Load Blockly source maps.
+      {
+        test: /(blockly\/.*\.js)$/,
+        use: [require.resolve('source-map-loader')],
+        enforce: 'pre'
+      }
+    ].filter(Boolean)
+  },
+  // https://github.com/google/blockly-samples/blob/9974e85becaa8ad17e35b588b95391c85865dafd/plugins/dev-scripts/config/webpack.config.js#L118-L120
+  ignoreWarnings: [/Failed to parse source map/]
+});


### PR DESCRIPTION
Update links in repository, since it has been moved from `QuantStack` to `jupyter-robotics`.